### PR TITLE
Making Client and Index new-style python classes for easier extension

### DIFF
--- a/algoliasearch/algoliasearch.py
+++ b/algoliasearch/algoliasearch.py
@@ -72,7 +72,7 @@ Entry point in the Python API.
 You should instanciate a Client object with your ApplicationID, ApiKey and Hosts
 to start using Algolia Search API
 """
-class Client:
+class Client(object):
     """
     Algolia Search library initialization
     @param application_id the application ID you have in your admin interface
@@ -309,7 +309,7 @@ class Client:
             tag_filters = ','.join(map(lambda t: ''.join(['(', ','.join(t), ')']) if type(t) is list else str(t), tag_filters))
         return hmac.new(str.encode(private_api_key), str.encode(''.join([str(tag_filters), str(user_token or '')])),  hashlib.sha256).hexdigest()
 
-class Index:
+class Index(object):
     """
     Contains all the functions related to one index
     You should use Client.init_index(index_name) to retrieve this object

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -386,3 +386,19 @@ class ClientTest(unittest.TestCase):
     self.assertEquals(len(results['hits']), 1)
     self.assertEquals('Paris', results['hits'][0]['name'])
     self.assertEquals('Pa', results['hits'][0]['short_name'])
+
+  def test_subclassing(self):
+    class SubClient(algoliasearch.Client):
+      def __init__(self, *args, **kwargs):
+        super(SubClient, self).__init__(*args, **kwargs)
+        self._my_thing = 20
+
+      @property
+      def my_thing(self):
+        return self._my_thing
+
+    sub = SubClient(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
+    self.assertEquals(20, sub.my_thing)
+    res = self.client.list_indexes()
+    self.assertIn('items', res)
+


### PR DESCRIPTION
Greetings,

I was attempting to subclass Algolia's `Client` object in my own project, and found that it wasn't a new-style class. I changed `Client` and `Index` to be new-style and added a test that shows subclassing. All tests are passing, but I only tried with Python 2.7.3

Please let me know if you need me to massage this to get it merged.
