### PR TITLE
Allow tox to run the py35 profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 - pip install tox
 script:
 - tox
+python: 3.5
 env:
   matrix:
   - TOXENV=py26

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py32
     py33
     py34
+    py35
     coverage
 skip_missing_interpreters = True
 


### PR DESCRIPTION
The problem was due to the fact that travis does not yet have python 3.5 in its prebuilt image.
More here https://github.com/travis-ci/travis-ci/issues/4794