### PR TITLE
Add Dockerfile for Python 2.7 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:2-onbuild
+
+RUN apt-get install -y git 
+
+RUN git clone https://github.com/algolia/algoliasearch-client-python
+
+RUN cd algoliasearch-client-python
+
+RUN pip install --upgrade algoliasearch
+
+


### PR DESCRIPTION
This should install perfectly for Python 2.7, I found that installing in python 3.4 gives me an error and some other Python 2.7.x installations locally without Docker. The only way I could install it was through Docker successfully. Let me know If you want me to make more Dockerfiles for other python installations or if there is any more to add.