### PR TITLE
Make VERSION easier to access

### DIFF
--- a/algoliasearch/__init__.py
+++ b/algoliasearch/__init__.py
@@ -25,10 +25,13 @@ THE SOFTWARE.
 from . import client
 from . import index
 from . import helpers
+from . import version
 
 
 # Compatibility with old import
 class algoliasearch(object):
+    VERSION = version.VERSION
+
     Client = client.Client
     Index = index.Index
     AlgoliaException = helpers.AlgoliaException


### PR DESCRIPTION
Until now `algoliasearch.version.VERSION` was needed to obtain the current version. Only `algoliasearch.VERSION` is now needed.
The change is backward compatible: it is still possible to do `algoliasearch.version.VERSION`.