### PR TITLE
Include large API keys in the JSON body instead of as a header

### DIFF
--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -78,19 +78,15 @@ class Client(object):
             self._transport.read_hosts = hosts
             self._transport.write_hosts = hosts
 
-        transport_headers = {
+        self._transport.headers = {
             'X-Algolia-Application-Id': app_id,
             'Content-Type': 'gzip',
             'Accept-Encoding': 'gzip',
             'User-Agent': 'Algolia for Python (%s)' % VERSION
         }
-        if len(api_key) <= MAX_API_KEY_LENGTH:
-            transport_headers['X-Algolia-API-Key'] = api_key
-
-        self._transport.headers.update(transport_headers)
 
         self._app_id = app_id
-        self._api_key = api_key
+        self.api_key = api_key
 
         # Fix for AppEngine bug when using urlfetch_stub
         if 'google.appengine.api.apiproxy_stub_map' in sys.modules.keys():
@@ -123,7 +119,8 @@ class Client(object):
     @api_key.setter
     def api_key(self, value):
         self._api_key = value
-        self.set_extra_headers(**{'X-Algolia-API-Key': value})
+        if len(value) <= MAX_API_KEY_LENGTH:
+            self.set_extra_headers(**{'X-Algolia-API-Key': value})
 
     @deprecated
     def enableRateLimitForward(self, admin_api_key, end_user_ip,

--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -119,7 +119,10 @@ class Client(object):
     @api_key.setter
     def api_key(self, value):
         self._api_key = value
-        if len(value) <= MAX_API_KEY_LENGTH:
+        if len(value) > MAX_API_KEY_LENGTH:
+            # If it was previously set, remove the header
+            self.headers.pop('X-Algolia-API-Key', None)
+        else:
             self.set_extra_headers(**{'X-Algolia-API-Key': value})
 
     @deprecated

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import unittest
 
-from algoliasearch.client import Client
+from algoliasearch.client import Client, MAX_API_KEY_LENGTH
 
 from .helpers import safe_index_name
 from .helpers import get_api_client
@@ -87,6 +87,20 @@ class ClientNoDataOperationsTest(ClientTest):
         client.api_key = 'your_api_key'
         self.assertEqual(client._api_key, 'your_api_key')
         self.assertEqual(client.headers['X-Algolia-API-Key'], 'your_api_key')
+
+    def test_change_api_key_too_long(self):
+        client = get_api_client()
+        api_key = 'a' * (MAX_API_KEY_LENGTH + 1)
+        client.api_key = api_key
+        self.assertEqual(client._api_key, api_key)
+        self.assertFalse('X-Algolia-API-Key' in client.headers)
+
+    def test_change_api_key_max_length(self):
+        client = get_api_client()
+        api_key = 'a' * MAX_API_KEY_LENGTH
+        client.api_key = api_key
+        self.assertEqual(client._api_key, api_key)
+        self.assertEqual(client.headers['X-Algolia-API-Key'], api_key)
 
     def test_subclassing_client(self):
         class SubClient(Client):

--- a/tests/test_old.py
+++ b/tests/test_old.py
@@ -59,11 +59,11 @@ class ClientTest(unittest.TestCase):
             pass
 
     def test_retry(self):
-      try:
-          client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], ["fakeapp-1.algolianet.com", "fakeapp-2.algolianet.com", os.environ['ALGOLIA_APPLICATION_ID'] + ".algolianet.com"])
-          client.listIndexes
-      except algoliasearch.AlgoliaException as e:
-          self.assertTrue(false)
+        try:
+            client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], ["fakeapp-1.algolianet.com", "fakeapp-2.algolianet.com", os.environ['ALGOLIA_APPLICATION_ID'] + ".algolianet.com"])
+            client.listIndexes
+        except algoliasearch.AlgoliaException as e:
+            self.assertTrue(false)
 
     def test_network(self):
         batch = []

--- a/tests/test_old.py
+++ b/tests/test_old.py
@@ -63,7 +63,7 @@ class ClientTest(unittest.TestCase):
             client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], ["fakeapp-1.algolianet.com", "fakeapp-2.algolianet.com", os.environ['ALGOLIA_APPLICATION_ID'] + ".algolianet.com"])
             client.listIndexes
         except algoliasearch.AlgoliaException as e:
-            self.assertTrue(false)
+            self.assertTrue(False)
 
     def test_network(self):
         batch = []


### PR DESCRIPTION
This mirrors the behavior of the JS client. The algolia API server will reject requests with headers that are too long.