### PR TITLE
Index: implement get_objects with attributes_to_retrieve

### DIFF
--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -82,7 +82,6 @@ class Index(object):
         self.index_name = index_name
         self._request_path = '/1/indexes/%s' % safe(self.index_name)
 
-
     @deprecated
     def addObject(self, content, object_id=None):
         return self.add_object(content, object_id)
@@ -141,19 +140,20 @@ class Index(object):
     def getObjects(self, object_ids):
         return self.get_objects(object_ids)
 
-    def get_objects(self, object_ids):
+    def get_objects(self, object_ids, attributes_to_retrieve=None):
         """
         Get several objects from this index.
 
         @param object_ids the array of unique identifier of objects to retrieve
+        @param attributes_to_retrieve (optional) if set, contains the list
+            of attributes to retrieve as a string separated by a comma
         """
-
         requests = []
         for object_id in object_ids:
-            requests.append({
-                'indexName': self.index_name,
-                'objectID': object_id
-            })
+            request = {'indexName': self.index_name, 'objectID': object_id}
+            if attributes_to_retrieve is not None:
+                request['attributesToRetrieve'] = ",".join(attributes_to_retrieve)
+            requests.append(request)
         data = {'requests': requests}
         path = '/1/indexes/*/objects'  # Use client._req()
         return self.client._req(True, path, 'POST', data=data)
@@ -487,7 +487,7 @@ class Index(object):
         for i in range(1, len(answers['results'])):
             for facet in answers['results'][i]['facets']:
                 aggregated_answer['disjunctiveFacets'][facet] = (
-                        answers['results'][i]['facets'][facet])
+                    answers['results'][i]['facets'][facet])
 
                 if facet not in disjunctive_refinements:
                     continue

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -62,16 +62,16 @@ class ClientNoDataOperationsTest(ClientTest):
         self.assertEqual(self.client.headers['X-Forwarded-For'], '192.168.0.1')
 
     def test_set_extra_headers(self):
-        self.client.set_extra_headers(Private=True)
+        self.client.set_extra_headers(Private="on")
         self.assertIn('Private', self.client.headers)
-        self.assertEqual(self.client.headers['Private'], True)
+        self.assertEqual(self.client.headers['Private'], "on")
 
         self.client.set_extra_headers(**{
-            'X-User': 223254,
+            'X-User': '223254',
             'X-Privacy-Settings': 'NSA-Free'
         })
         self.assertIn('X-User', self.client.headers)
-        self.assertEqual(self.client.headers['X-User'], 223254)
+        self.assertEqual(self.client.headers['X-User'], '223254')
         self.assertIn('X-Privacy-Settings', self.client.headers)
         self.assertEqual(self.client.headers['X-Privacy-Settings'], 'NSA-Free')
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -212,6 +212,15 @@ class IndexWithReadOnlyDataTest(IndexTest):
         self.assertDictContainsSubset(self.objs[0], res['results'][1])
         self.assertDictContainsSubset(self.objs[2], res['results'][2])
 
+    def test_get_objects_with_attributes_to_retrieve(self):
+        res = self.index.get_objects(self.objectIDs[1:3], attributes_to_retrieve=['name', 'email'])
+        for obj, obj_res in zip(self.objs[1:3], res['results']):
+            self.assertEqual(obj['name'], obj_res['name'])
+            self.assertEqual(obj['email'], obj_res['email'])
+            self.assertNotIn('phone', obj_res)
+            self.assertNotIn('city', obj_res)
+            self.assertNotIn('country', obj_res)
+
     def test_browse(self):
         res = self.index.browse(page=0, hits_per_page=2)
         self.assertEqual(res['page'], 0)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -16,9 +16,9 @@ except ImportError:
 from algoliasearch.client import MAX_API_KEY_LENGTH
 from algoliasearch.helpers import AlgoliaException
 
-from .helpers import safe_index_name
-from .helpers import get_api_client
-from .helpers import FakeData
+from tests.helpers import safe_index_name
+from tests.helpers import get_api_client
+from tests.helpers import FakeData
 
 
 class IndexTest(unittest.TestCase):


### PR DESCRIPTION
getObjects did not expose the attributesToRetrieve parameter, as noticed in [algoliasearch-client-android's #129](https://github.com/algolia/algoliasearch-client-android/issues/129).

Fixed in this PR by adding a default parameter and an unit-test.
