### PR TITLE
Fix datetime timestamp conversion when datetime is not in local time

### DIFF
--- a/algoliasearch/helpers.py
+++ b/algoliasearch/helpers.py
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import calendar
+import datetime
+import decimal
+import json
 import sys
 import warnings
-import json
-import decimal
-import time
-import datetime
 
 try:
     from urllib import quote
@@ -102,7 +102,7 @@ class CustomJSONEncoder(json.JSONEncoder):
             return float(obj)
         elif isinstance(obj, datetime.datetime):
             try:
-                return int(time.mktime(obj.timetuple()))
+                return int(calendar.timegm(obj.utctimetuple()))
             except:
                 return 0
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import os
-import time
+import calendar
 from random import randint
 from decimal import Decimal
 from datetime import datetime
@@ -111,7 +111,7 @@ class IndexWithoutDataTest(IndexTest):
         self.index.wait_task(task['taskID'])
 
         res = self.index.get_object(task['objectID'])
-        self.assertEqual(res['now'], time.mktime(value.timetuple()))
+        self.assertEqual(res['now'], calendar.timegm(value.utctimetuple()))
 
     def test_synonyms(self):
         task = self.index.add_object({'name': '589 Howard St., San Francisco'})


### PR DESCRIPTION
Use `calendar.timegm` and `datetime.utctimetuple` to handle non-local datetime timestamp conversion correctly.

References:
https://docs.python.org/3/library/time.html#time.mktime
https://docs.python.org/3/library/calendar.html#calendar.timegm