### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2818,6 +2818,8 @@ The REST API lets your interact directly with Algolia platforms from anything th
 
 
 # Troubleshooting
+**Test on RapidAPI** - You can explore the Algolia API on [RapidAPI](https://rapidapi.com/package/Algolia/functions?utm_source=AlgoliaGitHub&utm_medium=button).
+
 
 
 


### PR DESCRIPTION
Similar to my other pull request I've added a link in your README to Algolia's functions page in RapidAPI. I've done this for a few Algolia SDKs to help those who are reading the READMEs, understand and test the API before use.