### PR TITLE
ci: remove automatic testing of py26 and py32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ script:
 python: 3.5
 env:
   matrix:
-  - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=py35

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -210,7 +210,8 @@ class IndexWithoutDataTest(IndexTest):
         rule = get_rule_stub()
         rule2 = get_rule_stub('my-second-rule')
 
-        self.index.save_rule(rule);
+        res = self.index.save_rule(rule);
+        self.index.wait_task(res['taskID'])
         res = self.index.save_rule(rule2);
         self.index.wait_task(res['taskID'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-    py26
     py27
-    py32
     py33
     py34
     py35


### PR DESCRIPTION
Those versions are not compatible anymore with some of our
dependencies, which causes the tests to fail no matter what.