### PR TITLE
fix(Client/Index/Transport): Make request_options optional

### DIFF
--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -677,7 +677,7 @@ class Client(object):
         """
         return self._req(True, '/1/isalive', 'GET', request_options)
 
-    def _req(self, is_search, path, meth, request_options, params=None, data=None):
+    def _req(self, is_search, path, meth, request_options=None, params=None, data=None):
         if len(self.api_key) > MAX_API_KEY_LENGTH:
             if data is None:
                 data = {}

--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -1130,7 +1130,7 @@ class Index(object):
 
         return self._req(True, '/rules/search', 'POST', request_options, data=params)
 
-    def _req(self, is_search, path, meth, request_options, params=None, data=None):
+    def _req(self, is_search, path, meth, request_options=None, params=None, data=None):
         """Perform an HTTPS request with retry logic."""
         path = '%s%s' % (self._request_path, path)
         return self.client._req(is_search, path, meth, request_options, params, data)

--- a/algoliasearch/transport.py
+++ b/algoliasearch/transport.py
@@ -140,7 +140,7 @@ class Transport(object):
             else:
                 return self._original_write_hosts
 
-    def req(self, is_search, path, meth, params, data, request_options):
+    def req(self, is_search, path, meth, params, data, request_options=None):
         """Perform an HTTPS request with retry logic."""
 
         # Merge params and request_options params.


### PR DESCRIPTION
Fixes the [algoliasearch-async issue](https://github.com/algolia/algoliasearch-client-python/pull/301#issuecomment-341087416) reported by @talaus-signifai.