### PR TITLE
refactor(client/index): expose wait_task on the client

### DIFF
--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -689,6 +689,22 @@ class Client(object):
         """
         return self._req(True, '/1/isalive', 'GET', request_options)
 
+    def wait_task(self, task_id, time_before_retry=100, request_options=None):
+        """
+        Wait the publication of a task on the server.
+        All server task are asynchronous and you can check with this method
+        that the task is published.
+
+        @param task_id the id of the task returned by server
+        @param time_before_retry the time in milliseconds before retry (default = 100ms)
+        """
+        path = '/task/%d' % task_id
+        while True:
+            res = self._req(True, path, 'GET', request_options)
+            if res['status'] == 'published':
+                return res
+            time.sleep(time_before_retry / 1000.0)
+
     def _req(self, is_search, path, meth, request_options=None, params=None, data=None):
         if len(self.api_key) > MAX_API_KEY_LENGTH:
             if data is None:

--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -719,12 +719,7 @@ class Index(object):
         @param task_id the id of the task returned by server
         @param time_before_retry the time in milliseconds before retry (default = 100ms)
         """
-        path = '/task/%d' % task_id
-        while True:
-            res = self._req(True, path, 'GET', request_options)
-            if res['status'] == 'published':
-                return res
-            time.sleep(time_before_retry / 1000.0)
+        return self.client.wait_task(task_id, time_before_retry, request_options)
 
     def is_task_published(self, task_id, request_options=None):
         '''


### PR DESCRIPTION
Exposes `wait_task` on clients, to avoid requiring an index reference for an operation that does not need it.

The end goal is to leverage it in algoliasearch_django, to avoid code like this:
```python
    def test_delete_signal(self):
        Website.objects.create(name='Algolia', url='https://www.algolia.com')
        Website.objects.create(name='Google', url='https://www.google.com')
        Website.objects.create(name='Facebook', url='https://www.facebook.com')

        Website.objects.get(name='Algolia').delete()
        Website.objects.get(name='Facebook').delete()

        time.sleep(10)
        result = raw_search(Website)
        self.assertEqual(result['nbHits'], 1)
        self.assertEqual(result['hits'][0]['name'], 'Google')
```