### PR TITLE
fix: Prevent saving a rule with an empty objectID

### DIFF
--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -1059,6 +1059,8 @@ class Index(object):
         """
         if 'objectID' not in rule:
             raise AlgoliaException('missing objectID in rule body')
+        if rule['objectID'] == '':
+            raise AlgoliaException('objectID in rule body cannot be empty')
         params = {'forwardToReplicas': forward_to_replicas}
         return self._req(False, '/rules/%s' % str(rule['objectID']), 'PUT', request_options, params, rule)
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -208,6 +208,18 @@ def test_save_and_get_rule(index):
     assert index.read_rule('my-rule') == rule
 
 
+def test_empty_objectID_for_rule_should_raise_exception(index):
+    rule = rule_stub()
+    rule['objectID'] = ''
+
+    try:
+        index.save_rule(rule)
+    except AlgoliaException:
+        return
+
+    # We should not be able to save a rule with an empty objectID.
+    assert False
+
 def test_delete_rule(index):
     rule = rule_stub()
     res = index.save_rule(rule)


### PR DESCRIPTION
Follow up of https://github.com/algolia/algoliasearch-client-go/issues/397.