### PR TITLE
Browse: Ensure cursor is passed in the body

### DIFF
--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -551,7 +551,11 @@ class Index(object):
             params = {}
         if cursor:
             params = {'cursor': cursor}
-        return self._req(True, '/browse', 'GET', request_options, params)
+
+        if not params:
+            return self._req(True, '/browse', 'GET', request_options, params)
+        else:
+            return self._req(True, '/browse', 'POST', request_options, None, params)
 
     def browse_all(self, params=None, request_options=None):
         """

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -391,6 +391,12 @@ def test_browse_all(ro_index):
     assert set(ro_index.ids) == set(res_ids)
 
 
+def test_browse_from(ro_index):
+    tmp = ro_index.browse(0, 4)
+    it = ro_index.browse_from(cursor=tmp['cursor'])
+    assert len(it['hits']) == 1
+
+
 def test_search(ro_index):
     res = ro_index.search('')
     assert res['nbHits'] == 5


### PR DESCRIPTION
Cursor can get very long and exceed the max url size, for that reason we always pass it in the body of the request.

In case params is empty, we need to fallback on GET, because Algolia's API doesn't allow POST request with an empty body.