### PR TITLE
[2.0] Don't mutate query object

### DIFF
--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -238,7 +238,7 @@ class Client(object):
 
         requests = []
         for query in queries:
-            index_name = query.pop(index_name_key)
+            index_name = query[index_name_key]
 
             requests.append({
                 'indexName': index_name,


### PR DESCRIPTION
Previously index_name was popped so that subsequent queries could not be run on the same query object