### PR TITLE
Fix deleteObject needs a valid object_id

### DIFF
--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -287,6 +287,9 @@ class Index(object):
 
         @param object_id the unique identifier of object to delete
         """
+        if not object_id:
+            raise AlgoliaException('object_id cannot be empty')
+
         path = '/%s' % safe(object_id)
         return self._req(False, path, 'DELETE', request_options)
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## What was changed

`Index::delete_object` needs a non-empty objectID

## Why it was changed

If the object_id is empty, the entire index will be deleted instead of one record.