### PR TITLE
feat: add multiple objects endpoint methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 * Adds `AccountClient.copy_index` methods on client - PR [#391](https://github.com/algolia/algoliasearch-client-python/pull/391)
 
+* Adds `multiple_batch`, `multiple_get_objects` methods on client - PR [#379](https://github.com/algolia/algoliasearch-client-python/pull/379)
+
 ### 1.17.0 - 2018-06-19
 
 * Introduce AB Testing feature - PR [#408](https://github.com/algolia/algoliasearch-client-php/pull/#408)

--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -260,7 +260,7 @@ class Client(object):
         path = '/1/indexes/*/objects'
         return self._req(False, path, 'POST', request_options, data=requests)
 
-    def multiple_batch_objects(self, operations, request_options=None):
+    def multiple_batch(self, operations, request_options=None):
         """Send a batch of write operations targeting multiple indices."""
         return self.batch(operations, request_options)
 

--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -253,15 +253,25 @@ class Client(object):
         return self._req(True, path, 'POST', request_options, data=data)
 
     def multiple_get_objects(self, requests, request_options=None):
-        """Send a get objects targeting multiple indices."""
+        """
+        Send a get objects targeting multiple indices.
+
+        @param requests the list of requests
+        @param request_options
+        """
         if isinstance(requests, (list, tuple)):
             requests = {'requests': requests}
 
         path = '/1/indexes/*/objects'
-        return self._req(False, path, 'POST', request_options, data=requests)
+        return self._req(True, path, 'POST', request_options, data=requests)
 
     def multiple_batch(self, operations, request_options=None):
-        """Send a batch of write operations targeting multiple indices."""
+        """
+        Send a batch of write operations targeting multiple indices.
+
+        @param requests the list of requests
+        @param request_options
+        """
         return self.batch(operations, request_options)
 
     def batch(self, requests, request_options=None):

--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -252,6 +252,18 @@ class Client(object):
         data = {'requests': requests, 'strategy': strategy}
         return self._req(True, path, 'POST', request_options, data=data)
 
+    def multiple_get_objects(self, requests, request_options=None):
+        """Send a get objects targeting multiple indices."""
+        if isinstance(requests, (list, tuple)):
+            requests = {'requests': requests}
+
+        path = '/1/indexes/*/objects'
+        return self._req(False, path, 'POST', request_options, data=requests)
+
+    def multiple_batch_objects(self, operations, request_options=None):
+        """Send a batch of write operations targeting multiple indices."""
+        return self.batch(operations, request_options)
+
     def batch(self, requests, request_options=None):
         """Send a batch request targeting multiple indices."""
         if isinstance(requests, (list, tuple)):


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## What was changed

We decided to expose more methods like `multiple_queries` to the client.

* `multiple_get_objects` allows you to get objects by objectID from multiple indices
* `multiple_batch_objects` allows you to add, update or delete objects from multiple indices. (note: the `batch` method already existed in the python client but we added this one for consistency with other cleints)

Related conversations:

* https://github.com/algolia/algoliasearch-client-php/pull/295
* https://github.com/algolia/algoliasearch-client-javascript/issues/710