### PR TITLE
Adds move_to on the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 
 <Contributors, please add your changes below this line>
 
-### [Unreleased]
-
 * Adds move method on index - PR [#386](https://github.com/algolia/algoliasearch-client-python/pull/386)
     You can now move an index to a new destination directly on the index object. Usage:
         ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 <Contributors, please add your changes below this line>
 
+### [Unreleased]
+
+* Adds move method on index - PR [#386](https://github.com/algolia/algoliasearch-client-python/pull/386)
+    You can now move an index to a new destination directly on the index object. Usage:
+        ```python
+        index = client.init_index('name');
+        index.move('new_name')
+        index.get_settings() # Get the settings of the `new_name` index
+        ```
 
 ### 1.17.0 - 2018-06-19
 
@@ -13,11 +22,11 @@
     Introduce new Analytics object, wrapper around the
     [Analytics API](https://www.algolia.com/doc/rest-api/analytics/) (more methods to come).
 
-* 2 methods about taskID initially available in the `Index` moved to the `Client`. 
-    You could get some taskID from the engine without necessarily have an instance of Index, 
+* 2 methods about taskID initially available in the `Index` moved to the `Client`.
+    You could get some taskID from the engine without necessarily have an instance of Index,
     instead of instantiating an index that you won't need, you can now call wait_task and get_task_status on the client.
     The original methods on the index still work and are **not** deprecated.
- 
+
     ```python
     client.wait_ask(index_name, taskID)
     client.get_task_status(index_name, taskID)
@@ -74,7 +83,7 @@ https://blog.algolia.com/travis-encrypted-variables-external-contributions/
     Cursor can become so long that the generated URL fails (error HTTP 414).
 
 * Chore: Add Python version to the UserAgent
- 
+
 ### 1.15.3 - 2018-03-15
 
 * Remove the `[security]` flair of `requests`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
     You can now move an index to a new destination directly on the index object. Usage:
         ```python
         index = client.init_index('name');
-        index.move('new_name')
+        index.move_to('new_name')
         index.get_settings() # Get the settings of the `new_name` index
         ```
 

--- a/algoliasearch/client.py
+++ b/algoliasearch/client.py
@@ -316,6 +316,7 @@ class Client(object):
     def moveIndex(self, src_index_name, dst_index_name):
         return self.move_index(src_index_name, dst_index_name)
 
+    @deprecated
     def move_index(self, src_index_name, dst_index_name, request_options=None):
         """
         Move an existing index.

--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -311,6 +311,22 @@ class Index(object):
             })
         return self.batch(requests, request_options=request_options)
 
+    def move(self, new_index_name, request_options=None):
+        """
+        Move the index.
+
+        @param new_index_name the new name of the
+            index (destination will be overriten if it already exist).
+        """
+        request = {'operation': 'move', 'destination': new_index_name}
+
+        res = self._req(False, '/operation', 'POST', request_options, data=request)
+
+        self.index_name = new_index_name
+        self._request_path = '/1/indexes/%s' % safe(self.index_name)
+
+        return res
+
     def search(self, query, args=None, request_options=None):
         """
         Search inside the index.
@@ -699,7 +715,7 @@ class Index(object):
     def iter_rules(self, hits_per_page=1000, request_options=None):
         page = 0
         response = self.search_rules(
-            '', page=page, 
+            '', page=page,
             hitsPerPage=hits_per_page, request_options=request_options
         )
 
@@ -712,7 +728,7 @@ class Index(object):
 
             page += 1
             response = self.search_rules(
-                '', page=page, 
+                '', page=page,
                 hitsPerPage=hits_per_page, request_options=request_options
             )
 

--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -311,7 +311,7 @@ class Index(object):
             })
         return self.batch(requests, request_options=request_options)
 
-    def move(self, new_index_name, request_options=None):
+    def move_to(self, new_index_name, request_options=None):
         """
         Move the index.
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -267,6 +267,27 @@ def test_batch_and_clear_rules(index):
     rules = index.search_rules()
     assert rules['nbHits'] == 0
 
+def test_move(index):
+    old_index_name = index.index_name
+    task = index.add_object({ "objectID": "Foo" })
+    index.wait_task(task['taskID'])
+
+    task = index.move('algolia-python-move')
+    index.wait_task(task['taskID'])
+
+    res = index.client.list_indexes()
+    res_names = [elt['name'] for elt in res['items']]
+
+    assert old_index_name not in res_names
+    assert index.index_name in res_names
+
+    res = index.get_object("Foo")
+    assert res['objectID'] == "Foo"
+
+    assert index.index_name == "algolia-python-move"
+    assert index._request_path == '/1/indexes/%s' % "algolia-python-move"
+
+    index.client.delete_index('algolia-python-move')  # Tear down
 
 def test_batch_and_clear_existing(index):
     rule = rule_stub()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -267,12 +267,12 @@ def test_batch_and_clear_rules(index):
     rules = index.search_rules()
     assert rules['nbHits'] == 0
 
-def test_move(index):
+def test_move_to(index):
     old_index_name = index.index_name
     task = index.add_object({ "objectID": "Foo" })
     index.wait_task(task['taskID'])
 
-    task = index.move('algolia-python-move')
+    task = index.move_to('algolia-python-move')
     index.wait_task(task['taskID'])
 
     res = index.client.list_indexes()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

This Pull Request adds the move method on the index. Usage:

```python
index = client.init_index('name');
index.move('new_name')
index.get_settings() # Get the settings of the `new_name` index
```