### PR TITLE
ci: use vm-based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ branches:
   only:
     - master
 
-sudo: false
-
 python:
   - "2.7"
   - "3.4"


### PR DESCRIPTION
this will become the default, so let's see if this breaks now https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | no
| Need Doc update   | no

