### PR TITLE
Fixes issue while using replace_all_objects without a valid `objectID`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### UNRELEASED
 
-
 <Contributors, please add your changes below this line>
+
+* Fixed issue while using replace_all_objects without valid `objectID` - PR [#393](https://github.com/algolia/algoliasearch-client-python/pull/393)
 
 ### 1.18.0 - 2018-11-23
 

--- a/algoliasearch/index.py
+++ b/algoliasearch/index.py
@@ -243,13 +243,13 @@ class Index(object):
             count += 1
 
             if count == batch_size:
-                response = tmp_index.save_objects(batch, request_options)
+                response = tmp_index.add_objects(batch, request_options)
                 responses.append(response)
                 batch = []
                 count = 0
 
         if batch:
-            response = tmp_index.save_objects(batch, request_options)
+            response = tmp_index.add_objects(batch, request_options)
             responses.append(response)
 
         if safe:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -581,7 +581,10 @@ def test_replace_all_objects(index):
     response = index.save_objects([obj1, obj2])
     index.wait_task(response['taskID'])
 
-    obj3 = {'objectID': 'C', 'color': 'green'}
+    # Without object id.
+    obj3 = {'color': 'green'}
+
+    # With object id
     obj4 = {'objectID': 'D', 'color': 'yellow'}
     responses = index.replace_all_objects([obj3, obj4])
     for response in responses:
@@ -595,7 +598,8 @@ def test_replace_all_objects(index):
     assert len(res['hits']) == 2
     assert obj1 not in res['hits']
     assert obj2 not in res['hits']
-    assert obj3 in res['hits']
+
+    assert res['hits'][1]['color'] == 'green'
     assert obj4 in res['hits']
 
 
@@ -605,8 +609,11 @@ def test_replace_all_objects_with_safe(index):
     response = index.save_objects([obj1, obj2])
     index.wait_task(response['taskID'])
 
-    obj3 = {'objectID': 'C', 'color': 'green'}
-    obj4 = {'objectID': 'D', 'color': 'yellow'}
+    # Without object id.
+    obj3 = {'color': 'black'}
+
+    # With object id
+    obj4 = {'objectID': 'D', 'color': 'white'}
     request_options = RequestOptions({'safe': True})
     index.replace_all_objects([obj3, obj4], request_options)
 
@@ -618,7 +625,7 @@ def test_replace_all_objects_with_safe(index):
     assert len(res['hits']) == 2
     assert obj1 not in res['hits']
     assert obj2 not in res['hits']
-    assert obj3 in res['hits']
+    assert res['hits'][1]['color'] == 'black'
     assert obj4 in res['hits']
 
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no
| Need Doc update   | no

## What problem is this fixing?

Bug: If you try to call `replace_all_objects` with a set of objects without a valid `objectID` the library will raise this error: 
```python
KeyError: 'objectID'
```

The solution is the usage of the method `addObjects` instead of the `saveObjects`, because this last one requires a valid `objectID`.