### PR TITLE
make double quotes usage consistent in Python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ You can find both on [your Algolia account](https://www.algolia.com/api-keys).
 ```python
 from algoliasearch import algoliasearch
 
-client = algoliasearch.Client("YourApplicationID", 'YourAPIKey')
-index = client.init_index('your_index_name')
+client = algoliasearch.Client("YourApplicationID", "YourAPIKey")
+index = client.init_index("your_index_name")
 ```
 
 ## Push data
@@ -76,7 +76,7 @@ index = client.init_index('your_index_name')
 Without any prior configuration, you can start indexing [500 contacts](https://github.com/algolia/datasets/blob/master/contacts/contacts.json) in the ```contacts``` index using the following code:
 ```python
 index = client.init_index("contacts")
-batch = json.load(open('contacts.json'))
+batch = json.load(open("contacts.json"))
 index.add_objects(batch)
 ```
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

Single and double quotes were mixed freely in the Python code blocks. There were more double than single, so went with double throughout.

## What problem is this fixing?

Nothing functional, just conveys a cleaner, more readable code base to other devs. 
