### PR TITLE
Fixes chunk algorithm on batch size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # Release Notes
 
+## [Unreleased]
+
+### Fixed
+- Batching algorithm when reaching the `batch_size`. ([#421](https://github.com/algolia/algoliasearch-client-python/pull/421))
+
 ## [v2.0.0](https://github.com/algolia/algoliasearch-client-python/compare/1.20.0...2.0.0)
 
 ### Changed

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -498,17 +498,17 @@ class SearchIndex(object):
 
             if len(batch) == batch_size:
                 if validate_object_id:
-                    assert_object_id(objects)
+                    assert_object_id(batch)
 
-                requests = build_raw_response_batch(action, objects)
+                requests = build_raw_response_batch(action, batch)
                 raw_responses.append(
                     self._raw_batch(requests, request_options))
                 batch = []
 
         if len(batch):
             if validate_object_id:
-                assert_object_id(objects)
-            requests = build_raw_response_batch(action, objects)
+                assert_object_id(batch)
+            requests = build_raw_response_batch(action, batch)
             raw_responses.append(self._raw_batch(requests, request_options))
 
         return IndexingResponse(self, raw_responses)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Need Doc update   | no

## What problem is this fixing?

The `batch ` algorithm was broken as it was sending to Algolia the list of objects instead of the batch it self.