### PR TITLE
Fix conflict with standard library for typing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,10 @@
 
 # Requirements
 requests>=2.21,<3.0
-typing>=3.6,<4.0
+
+# Typing is included in the Python standard library as of 3.5
+# See - https://docs.python.org/3/library/typing.html
+typing>=3.6,<4.0; python_version < '3.5'
 
 # Dev requirements
 -r requirements/requirements-testing.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ include_package_data = True
 packages = find:
 install_requires =
     requests>=2.21,<3.0
-    typing>=3.6,<4.0
+    typing>=3.6,<4.0;python_version<"3.5"
 python_requires = >=2.7, !=3.0.*, !=3.1.*', !=3.2.*, !=3.3.*'
 
 [options.packages.find]


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #422  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change
I've changed the typing requirement to only be installed if the python version is less than 3.5. This is because `typing` is included in the standard library for 3.5 and above. You can read more here https://docs.python.org/3/library/typing.html and in issue #422 
<!--
    Please describe your change, add as much detail as
    necessary to understand your code.
-->

## What problem is this fixing?
The issue described in #422 

<!--
    Please include everything needed to understand the problem,
    its context and consequences, and, if possible, how to recreate it.
-->
