### PR TITLE
Apply attributesToRetrieve parameter to each request created by index.get_objects

### DIFF
--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -131,15 +131,15 @@ class SearchIndex(object):
                 self._config,
                 request_options
             )
+        # store attributesToRetrieve for use in each request
+        attributes_to_retrieve = request_options.data.pop('attributesToRetrieve', None)
 
         requests = []
         for object_id in object_ids:
             request = {'indexName': self._name, 'objectID': str(object_id)}
 
-            if 'attributesToRetrieve' in request_options.data:
-                request['attributesToRetrieve'] = request_options.data.pop(
-                    'attributesToRetrieve'
-                )
+            if attributes_to_retrieve:
+                request['attributesToRetrieve'] = attributes_to_retrieve
 
             requests.append(request)
 

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -138,6 +138,32 @@ class TestSearchIndex(unittest.TestCase):
 
         self.assertNotIn('attributesToRetrieve', request_options.data)
 
+    def test_get_objects_with_attributes_to_retreive_bulk(self):
+        request_options = RequestOptions.create(self.config, {
+            'attributesToRetrieve': ['firstname', 'lastname']
+        })
+
+        requests = [{
+            'indexName': 'index-name',
+            'objectID': 'foo_id',
+            'attributesToRetrieve': ['firstname', 'lastname']
+        }, {
+            'indexName': 'index-name',
+            'objectID': 'bar_id',
+            'attributesToRetrieve': ['firstname', 'lastname']
+        }]
+
+        self.index.get_objects(['foo_id', 'bar_id'], request_options)
+
+        self.transporter.read.assert_called_once_with(
+            'POST',
+            '1/indexes/*/objects',
+            {'requests': requests},  # asserts version 2 it's used.
+            request_options
+        )
+
+        self.assertNotIn('attributesToRetrieve', request_options.data)
+
     def test_get_settings(self):
         self.transporter.read.return_value = {
             'attributesToIndex': ['attr1', 'attr2'],


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Pop `attributesToRetrieve` from `request_options` before iterating over object_ids in order to ensure that:
1) it's applied to each request created by the function
2) it's not present in the main request parameters

## What problem is this fixing?

Without this or a similar change, `attributesToRetrieve` is only applied to the first object, all other objects are retrieved with all attributes
