### PR TITLE
Fix get_settings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # Release Notes
 
+## Unreleased
+
+### Fixed
+- On `getVersion` param used by `search_index.get_settings` ([#426](https://github.com/algolia/algoliasearch-client-python/pull/426))
+
 ## [v2.0.3](https://github.com/algolia/algoliasearch-client-python/compare/2.0.2...2.0.3)
 
 ### Fixed

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -132,7 +132,8 @@ class SearchIndex(object):
                 request_options
             )
         # store attributesToRetrieve for use in each request
-        attributes_to_retrieve = request_options.data.pop('attributesToRetrieve', None)
+        attributes_to_retrieve = request_options.data.pop(
+            'attributesToRetrieve', None)
 
         requests = []
         for object_id in object_ids:
@@ -234,17 +235,16 @@ class SearchIndex(object):
     def get_settings(self, request_options=None):
         # type: (Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
 
-        params = {'getVersion': 2}
+        if request_options is None or isinstance(request_options, dict):
+            request_options = RequestOptions.create(self._config,
+                                                    request_options)
 
-        if request_options is None:
-            request_options = {'getVersion':2}
-        else:
-            request_options.append({'getVersion':2})
+        request_options.query_parameters['getVersion'] = 2
 
         raw_response = self._transporter.read(
             Verb.GET,
             endpoint('1/indexes/{}/settings', self._name),
-            params,
+            None,
             request_options
         )
 

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -236,6 +236,11 @@ class SearchIndex(object):
 
         params = {'getVersion': 2}
 
+        if request_options is None:
+            request_options = {'getVersion':2}
+        else:
+            request_options.append({'getVersion':2})
+
         raw_response = self._transporter.read(
             Verb.GET,
             endpoint('1/indexes/{}/settings', self._name),

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -80,12 +80,15 @@ class SearchIndexAsync(SearchIndex):
     def get_settings_async(self, request_options=None):  # type: ignore
         # type: (Optional[Union[dict, RequestOptions]]) -> dict
 
-        params = {'getVersion': 2}
+        if request_options == None:
+            request_options = {'getVersion':2}
+        else:
+            request_options.append({'getVersion':2})
 
         raw_response = yield from self._transporter_async.read(
             Verb.GET,
             endpoint('1/indexes/{}/settings', self._name),
-            params,
+            None,
             request_options
         )
 

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -80,10 +80,11 @@ class SearchIndexAsync(SearchIndex):
     def get_settings_async(self, request_options=None):  # type: ignore
         # type: (Optional[Union[dict, RequestOptions]]) -> dict
 
-        if request_options == None:
-            request_options = {'getVersion':2}
-        else:
-            request_options.append({'getVersion':2})
+        if request_options is None or isinstance(request_options, dict):
+            request_options = RequestOptions.create(self._config,
+                                                    request_options)
+
+        request_options.query_parameters['getVersion'] = 2
 
         raw_response = yield from self._transporter_async.read(
             Verb.GET,

--- a/tests/features/test_account_client.py
+++ b/tests/features/test_account_client.py
@@ -46,6 +46,18 @@ class TestAccountClient(unittest.TestCase):
         self.assertEqual(self.index2.get_rule('one'), rule)
 
         # Assert synonyms got copied
+        list_synonyms1 = []
+        list_synonyms2 = []
+
+        for synonym1 in self.index.browse_synonyms():
+            list_synonyms1.append(synonym1)
+
+        for synonym2 in self.index2.browse_synonyms():
+            list_synonyms2.append(synonym2)
+
+        self.assertEqual(list_synonyms1,list_synonyms1)
+
+        # Assert synomys are the same
         self.assertEqual(self.index2.get_synonym('one'), synonym)
 
         # Assert that copying again fails because index already exists

--- a/tests/features/test_account_client.py
+++ b/tests/features/test_account_client.py
@@ -46,16 +46,10 @@ class TestAccountClient(unittest.TestCase):
         self.assertEqual(self.index2.get_rule('one'), rule)
 
         # Assert synonyms got copied
-        list_synonyms1 = []
-        list_synonyms2 = []
+        list_synonyms1 = [synonym for synonym in self.index.browse_synonyms()]
+        list_synonyms2 = [synonym for synonym in self.index2.browse_synonyms()]
 
-        for synonym1 in self.index.browse_synonyms():
-            list_synonyms1.append(synonym1)
-
-        for synonym2 in self.index2.browse_synonyms():
-            list_synonyms2.append(synonym2)
-
-        self.assertEqual(list_synonyms1,list_synonyms1)
+        self.assertEqual(list_synonyms1, list_synonyms2)
 
         # Assert synomys are the same
         self.assertEqual(self.index2.get_synonym('one'), synonym)

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -178,7 +178,7 @@ class TestSearchIndex(unittest.TestCase):
         self.transporter.read.assert_called_once_with(
             'GET',
             '1/indexes/index-name/settings',
-            None,  # asserts version 2 it's used.
+            None,
             request_options
         )
 

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -205,7 +205,7 @@ class TestSearchIndex(unittest.TestCase):
 
         self.assertEqual(args[3].query_parameters['getVersion'], 2)
 
-    def test_get_settings_dict_as_request_options(self):
+    def test_get_settings_with_request_options(self):
         request_options = RequestOptions.create(self.config, {'foo': 'bar'})
 
         self.index.get_settings(request_options)

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -172,14 +172,17 @@ class TestSearchIndex(unittest.TestCase):
             'ignorePlurals': True,
         }
 
-        settings = self.index.get_settings({'foo': 'bar'})
+        request_options = RequestOptions.create(self.config, {'foo': 'bar'})
+        settings = self.index.get_settings(request_options)
 
         self.transporter.read.assert_called_once_with(
             'GET',
             '1/indexes/index-name/settings',
-            {'getVersion': 2},  # asserts version 2 it's used.
-            {'foo': 'bar'}
+            None,  # asserts version 2 it's used.
+            request_options
         )
+
+        self.assertEqual(request_options.query_parameters['getVersion'], 2)
 
         self.assertEqual(settings, {
             'searchableAttributes': ['attr1', 'attr2'],
@@ -187,6 +190,29 @@ class TestSearchIndex(unittest.TestCase):
             'replicas': ['index1', 'index2'],
             'ignorePlurals': True,
         })
+
+    def test_get_settings_none_as_request_options(self):
+        self.index.get_settings()
+
+        args = self.transporter.read.call_args[0]
+
+        self.assertEqual(args[3].query_parameters['getVersion'], 2)
+
+    def test_get_settings_dict_as_request_options(self):
+        self.index.get_settings({'foo': 'bar'})
+
+        args = self.transporter.read.call_args[0]
+
+        self.assertEqual(args[3].query_parameters['getVersion'], 2)
+
+    def test_get_settings_dict_as_request_options(self):
+        request_options = RequestOptions.create(self.config, {'foo': 'bar'})
+
+        self.index.get_settings(request_options)
+
+        args = self.transporter.read.call_args[0]
+
+        self.assertEqual(args[3].query_parameters['getVersion'], 2)
 
     def test_save_synonyms(self):
         # Test null response


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      |no    
| BC breaks?        | no
| Related Issue     | [#425](https://github.com/algolia/algoliasearch-client-python/issues/425)
| Need Doc update   | no


## Description

There is a bug, getVersion=2 is meant to be set as a URL parameter and not a header.
With AccountClient we duplicate synonyms because getSettings without `getVersion=2` use as default `getVersion=1` and in the version 1 synonyms were consider as settings. 


## What it changes 

- Improve test suite with a robust test
- fix bug 
- correct getSettings method (sync/async) 
