### PR TITLE
added(settings): indexLanguages parameter

### DIFF
--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -165,6 +165,13 @@ class TestSearchIndex(unittest.TestCase):
             ['name']
         )
 
+        self.index.set_settings({'indexLanguages': ['ja']}).wait()
+
+        self.assertEqual(
+            self.index.get_settings()['indexLanguages'],
+            ['ja']
+        )
+
     def test_search(self):
         responses = MultipleResponse()
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix https://github.com/algolia/algoliasearch-client-python/issues/441
| Need Doc update   | yes


## Describe your change

Implement the new indexLanguages setting which is an array of strings.
Currently, only ["ja"] is supported by the engine.