### PR TITLE
internal: update query rule test with alternative

### DIFF
--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -387,7 +387,11 @@ class TestSearchIndex(unittest.TestCase):
 
         rule2 = {
             "objectID": "query_edits",
-            "condition": {"anchoring": "is", "pattern": "mobile phone"},
+            "condition": {
+                "anchoring": "is",
+                "pattern": "mobile phone",
+                "alternatives": True
+            },
             "consequence": {
                 "params": {
                     "query": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #442 
| Need Doc update   | no


## Describe your change

Adds the new `Alternatives` field in the concerned test.
Fix #442
