### PR TITLE
feat: unit test relevance

### DIFF
--- a/algoliasearch/exceptions.py
+++ b/algoliasearch/exceptions.py
@@ -25,5 +25,5 @@ class AlgoliaUnreachableHostException(Exception):
     pass
 
 
-class ObjectNotFoundException(Exception):
+class ObjectNotFoundException(AlgoliaException):
     pass

--- a/algoliasearch/exceptions.py
+++ b/algoliasearch/exceptions.py
@@ -23,3 +23,7 @@ class RequestException(AlgoliaException):
 
 class AlgoliaUnreachableHostException(Exception):
     pass
+
+
+class ObjectNotFoundException(Exception):
+    pass

--- a/algoliasearch/helpers.py
+++ b/algoliasearch/helpers.py
@@ -77,3 +77,14 @@ def sleep_for(retries_count, before_retry):
 
     factor = math.ceil(retries_count / 10)
     time.sleep(factor * before_retry / 1000000.0)
+
+
+def get_object_id_position(res, object_id):
+    # type: (dict, str) -> int
+    hits = res['hits']
+
+    for i, hit in enumerate(hits):
+        if hit.get('objectID') == object_id:
+            return i
+
+    return -1

--- a/algoliasearch/helpers.py
+++ b/algoliasearch/helpers.py
@@ -77,14 +77,3 @@ def sleep_for(retries_count, before_retry):
 
     factor = math.ceil(retries_count / 10)
     time.sleep(factor * before_retry / 1000000.0)
-
-
-def get_object_id_position(res, object_id):
-    # type: (dict, str) -> int
-    hits = res['hits']
-
-    for i, hit in enumerate(hits):
-        if hit.get('objectID') == object_id:
-            return i
-
-    return -1

--- a/algoliasearch/http/request_options.py
+++ b/algoliasearch/http/request_options.py
@@ -1,6 +1,6 @@
 import copy
 
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Dict, Union
 
 from algoliasearch.configs import Config
 from algoliasearch.helpers import get_items
@@ -29,7 +29,7 @@ class RequestOptions(object):
 
     @staticmethod
     def create(config, options=None):
-        # type: (Config, Optional[RequestOptions, Dict[str, Any]]) -> RequestOptions  # noqa: E501
+        # type: (Config, Optional[Union[RequestOptions, Dict[str, Any]]]) -> RequestOptions  # noqa: E501
 
         if isinstance(options, RequestOptions):
             return copy.copy(options)

--- a/algoliasearch/http/request_options.py
+++ b/algoliasearch/http/request_options.py
@@ -1,3 +1,5 @@
+import copy
+
 from typing import Optional, Any, Dict
 
 from algoliasearch.configs import Config
@@ -27,7 +29,10 @@ class RequestOptions(object):
 
     @staticmethod
     def create(config, options=None):
-        # type: (Config, Optional[Dict[str, Any]]) -> RequestOptions
+        # type: (Config, Optional[RequestOptions, Dict[str, Any]]) -> RequestOptions  # noqa: E501
+
+        if isinstance(options, RequestOptions):
+            return copy.copy(options)
 
         headers = dict(config.headers)
 

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -168,11 +168,12 @@ class SearchIndex(object):
             paginate = request_options.pop('paginate', paginate)
             query = request_options.pop('query', query)
 
+        request_options = RequestOptions.create(
+            self._config,
+            request_options
+        )
+
         while True:
-            request_options = RequestOptions.create(
-                self._config,
-                request_options
-            )
             request_options.data['page'] = page
 
             res = self.search(query, request_options)

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -4,7 +4,7 @@ import random
 import string
 import time
 
-from typing import Optional, List, Union, Iterator, Callable
+from typing import Any, Optional, Dict, List, Union, Iterator, Callable
 
 from algoliasearch.configs import SearchConfig
 from algoliasearch.exceptions import (
@@ -157,7 +157,7 @@ class SearchIndex(object):
         )
 
     def find_object(self, callback, request_options=None):
-        # type: (Callable[[Dict[str, any]], bool], Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
+        # type: (Callable[[Dict[str, Any]], bool], Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
 
         paginate = True
         query = ''

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -600,6 +600,16 @@ class SearchIndex(object):
 
         return IndexingResponse(self, [raw_response])
 
+    @staticmethod
+    def get_object_position(res, object_id):
+        # type: (Dict[str, Any], str) -> int
+
+        for i, hit in enumerate(res['hits']):
+            if hit.get('objectID') == object_id:
+                return i
+
+        return -1
+
     def _create_temporary_name(self):
         # type: () -> str
 

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -2,7 +2,7 @@ import copy
 
 import asyncio
 import math
-from typing import Optional, Union, List, Iterator, Callable
+from typing import Optional, Dict, Union, List, Iterator, Callable
 
 from algoliasearch.configs import SearchConfig
 from algoliasearch.exceptions import ObjectNotFoundException
@@ -97,7 +97,7 @@ class SearchIndexAsync(SearchIndex):
 
         return SettingsDeserializer.deserialize(raw_response)
 
-    def find_objec_async(self, callback, request_options=None):
+    def find_object_async(self, callback, request_options=None):  # type: ignore # noqa: E501
         # type: (Callable[[Dict[str, any]], bool], Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
 
         paginate = True
@@ -117,7 +117,7 @@ class SearchIndexAsync(SearchIndex):
         while True:
             request_options.data['page'] = page
 
-            res = yield from self.search(query, request_options)
+            res = yield from self.search_async(query, request_options)   # type: ignore # noqa: E501
 
             for pos, hit in enumerate(res['hits']):
                 if callback(hit):

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -109,11 +109,12 @@ class SearchIndexAsync(SearchIndex):
             paginate = request_options.pop('paginate', paginate)
             query = request_options.pop('query', query)
 
+        request_options = RequestOptions.create(
+            self._config,
+            request_options
+        )
+
         while True:
-            request_options = RequestOptions.create(
-                self._config,
-                request_options
-            )
             request_options.data['page'] = page
 
             res = yield from self.search(query, request_options)

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -2,7 +2,6 @@ import copy
 
 import asyncio
 import math
-import types
 from typing import Optional, Union, List, Iterator, Callable
 
 from algoliasearch.configs import SearchConfig
@@ -98,42 +97,41 @@ class SearchIndexAsync(SearchIndex):
 
         return SettingsDeserializer.deserialize(raw_response)
 
-    def find_first_object_async(self, filter_func, query, do_not_paginate=False, request_options=None):  # type: ignore # noqa: E501
-        # type: (Callable[[dict], bool], Optional[str], bool, Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
+    def find_objec_async(self, callback, request_options=None):
+        # type: (Callable[[Dict[str, any]], bool], Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
 
-        res = self.search(query, request_options)
+        paginate = True
+        query = ''
+        page = 0
 
-        hits = res['hits']
-        page = int(res['page'])
-        nb_pages = int(res['nbPages'])
-
-        for pos, hit in enumerate(hits):
-            if filter_func(hit):
-                return {
-                    'object': hit,
-                    'position': pos,
-                    'page': page,
-                }
-
-        has_next_page = page + 1 < nb_pages
-
-        if do_not_paginate or not has_next_page:
-            raise ObjectNotFoundException
-
-        if request_options is None or isinstance(request_options, dict):
-            request_options = RequestOptions.create(self._config,
-                                                    request_options)
-        else:
+        if isinstance(request_options, dict):
             request_options = copy.copy(request_options)
+            paginate = request_options.pop('paginate', paginate)
+            query = request_options.pop('query', query)
 
-        request_options['page'] = page + 1
+        while True:
+            request_options = RequestOptions.create(
+                self._config,
+                request_options
+            )
+            request_options.data['page'] = page
 
-        return self.find_first_object_async(
-            filter_func,
-            query,
-            do_not_paginate,
-            request_options,
-        )
+            res = yield from self.search(query, request_options)
+
+            for pos, hit in enumerate(res['hits']):
+                if callback(hit):
+                    return {
+                        'object': hit,
+                        'position': pos,
+                        'page': page,
+                    }
+
+            has_next_page = page + 1 < int(res['nbPages'])
+
+            if not paginate or not has_next_page:
+                raise ObjectNotFoundException
+
+            page += 1
 
     def replace_all_objects_async(self, objects,  # type: ignore
                                   request_options=None):

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -1,9 +1,12 @@
+import copy
+
 import asyncio
 import math
 import types
-from typing import Optional, Union, List, Iterator
+from typing import Optional, Union, List, Iterator, Callable
 
 from algoliasearch.configs import SearchConfig
+from algoliasearch.exceptions import ObjectNotFoundException
 from algoliasearch.helpers_async import _create_async_methods_in
 from algoliasearch.helpers import endpoint
 from algoliasearch.http.request_options import RequestOptions
@@ -94,6 +97,43 @@ class SearchIndexAsync(SearchIndex):
         )
 
         return SettingsDeserializer.deserialize(raw_response)
+
+    def find_first_object_async(self, filter_func, query, do_not_paginate=False, request_options=None):  # type: ignore # noqa: E501
+        # type: (Callable[[dict], bool], Optional[str], bool, Optional[Union[dict, RequestOptions]]) -> dict # noqa: E501
+
+        res = self.search(query, request_options)
+
+        hits = res['hits']
+        page = int(res['page'])
+        nb_pages = int(res['nbPages'])
+
+        for pos, hit in enumerate(hits):
+            if filter_func(hit):
+                return {
+                    'object': hit,
+                    'position': pos,
+                    'page': page,
+                }
+
+        has_next_page = page + 1 < nb_pages
+
+        if do_not_paginate or not has_next_page:
+            raise ObjectNotFoundException
+
+        if request_options is None or isinstance(request_options, dict):
+            request_options = RequestOptions.create(self._config,
+                                                    request_options)
+        else:
+            request_options = copy.copy(request_options)
+
+        request_options['page'] = page + 1
+
+        return self.find_first_object_async(
+            filter_func,
+            query,
+            do_not_paginate,
+            request_options,
+        )
 
     def replace_all_objects_async(self, objects,  # type: ignore
                                   request_options=None):

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -3,9 +3,8 @@ import sys
 import unittest
 
 from algoliasearch.exceptions import RequestException, ObjectNotFoundException
-from algoliasearch.helpers import get_object_id_position
-from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.responses import MultipleResponse
+from algoliasearch.search_index import SearchIndex
 from tests.helpers.factory import Factory as F
 
 
@@ -203,9 +202,13 @@ class TestSearchIndex(unittest.TestCase):
         # parameter and check that the number of returned hits is equal to 2
         result = self.index.search('algolia')
         self.assertEqual(result['nbHits'], 2)
-        self.assertEqual(get_object_id_position(result, 'nicolas-dessaigne'), 0)  # noqa: E501
-        self.assertEqual(get_object_id_position(result, 'julien-lemoine'), 1)
-        self.assertEqual(get_object_id_position(result, ''), -1)
+        self.assertEqual(SearchIndex.get_object_position(
+            result, 'nicolas-dessaigne'), 0
+        )
+        self.assertEqual(SearchIndex.get_object_position(
+            result, 'julien-lemoine'), 1
+        )`
+        self.assertEqual(SearchIndex.get_object_position(result, ''), -1)
 
         # Call find_first_object with the following parameters and check that
         # no object is found

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 
 from algoliasearch.exceptions import RequestException, ObjectNotFoundException
+from algoliasearch.helpers import get_object_id_position
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.responses import MultipleResponse
 from tests.helpers.factory import Factory as F
@@ -177,8 +178,8 @@ class TestSearchIndex(unittest.TestCase):
         responses = MultipleResponse()
 
         responses.push(self.index.save_objects([
-            {"company": "Algolia", "name": "Julien Lemoine"},
-            {"company": "Algolia", "name": "Nicolas Dessaigne"},
+            {"company": "Algolia", "name": "Julien Lemoine", "objectID": "julien-lemoine"},  # noqa: E501
+            {"company": "Algolia", "name": "Nicolas Dessaigne", "objectID": "nicolas-dessaigne"},  # noqa: E501
             {"company": "Amazon", "name": "Jeff Bezos"},
             {"company": "Apple", "name": "Steve Jobs"},
             {"company": "Apple", "name": "Steve Wozniak"},
@@ -202,6 +203,9 @@ class TestSearchIndex(unittest.TestCase):
         # parameter and check that the number of returned hits is equal to 2
         result = self.index.search('algolia')
         self.assertEqual(result['nbHits'], 2)
+        self.assertEqual(get_object_id_position(result, 'nicolas-dessaigne'), 0)  # noqa: E501
+        self.assertEqual(get_object_id_position(result, 'julien-lemoine'), 1)
+        self.assertEqual(get_object_id_position(result, ''), -1)
 
         # Call find_first_object with the following parameters and check that
         # no object is found

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -239,7 +239,7 @@ class TestSearchIndex(unittest.TestCase):
         # no object is found
         with self.assertRaises(ObjectNotFoundException):
             self.index.find_object(callback, {
-                'query': 'algolia',
+                'query': '',
                 'paginate': False,
                 'hitsPerPage': 5
             })

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -387,7 +387,11 @@ class TestSearchIndex(unittest.TestCase):
 
         rule2 = {
             "objectID": "query_edits",
-            "condition": {"anchoring": "is", "pattern": "mobile phone"},
+            "condition": {
+                "anchoring": "is",
+                "pattern": "mobile phone",
+                "alternatives": True
+            },
             "consequence": {
                 "params": {
                     "query": {

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -262,9 +262,11 @@ class TestSearchIndex(unittest.TestCase):
             'page': 0
         }).data)
 
-        self.index.find_object(lambda obj: True, RequestOptions.create(self.config, {
-            'User-Agent': 'blabla'
-        }))
+        self.index.find_object(lambda obj: True, RequestOptions.create(
+            self.config, {
+                'User-Agent': 'blabla'
+            }
+        ))
         args, _ = self.index.search.call_args
         self.assertEqual(args[0], '')
         self.assertEqual(args[1].data, RequestOptions.create(self.config, {


### PR DESCRIPTION
Close #439 

- [Specs and CTS tests](https://github.com/algolia/algoliasearch-client-specs-internal/pull/41)
- [Go client base implementation](https://github.com/algolia/algoliasearch-client-go/pull/524)

@nunomaduro Your review can wait until you come back from vacations (please!).

@nunomaduro @clemfromspace As I replied to Nuno in one of my comments, I'd really like to know if it's possible and how to avoid all the copy/pasting between the sync and async versions of the `search_index.find_first_object` function.