### PR TITLE
fix: makes unreachable be an algolia exception

### DIFF
--- a/algoliasearch/exceptions.py
+++ b/algoliasearch/exceptions.py
@@ -21,5 +21,5 @@ class RequestException(AlgoliaException):
         self.status_code = status_code
 
 
-class AlgoliaUnreachableHostException(Exception):
+class AlgoliaUnreachableHostException(AlgoliaException):
     pass


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Need Doc update   | no

This pull request makes all exceptions extend the default Algolia one. 