### PR TITLE
fix: adds request_options into exists method

### DIFF
--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -49,11 +49,11 @@ class SearchIndex(object):
         self._config = config
         self._name = name
 
-    def exists(self):
-        # type: () -> bool
+    def exists(self, request_options=None):
+        # type: (Optional[Union[dict, RequestOptions]]) -> bool
 
         try:
-            self.get_settings()
+            self.get_settings(request_options)
         except RequestException as e:
             if e.status_code == 404:
                 return False

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -79,11 +79,11 @@ class SearchIndexAsync(SearchIndex):
         return RuleIteratorAsync(self._transporter_async, self._name,
                                  request_options)
 
-    def exists_async(self):
-        # type: () -> bool
+    def exists_async(self, request_options=None):  # type: ignore # noqa: E501
+        # type: (Optional[Union[dict, RequestOptions]]) -> bool
 
         try:
-            yield from self.get_settings_async()
+            yield from self.get_settings_async(request_options)
         except RequestException as e:
             if e.status_code == 404:
                 return False


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #453 

Adds missing request_options into `exists` method.