### PR TITLE
feat(remaining-validity): adds get_secured_api_key_remaining_validity

### DIFF
--- a/algoliasearch/exceptions.py
+++ b/algoliasearch/exceptions.py
@@ -27,3 +27,7 @@ class AlgoliaUnreachableHostException(AlgoliaException):
 
 class ObjectNotFoundException(AlgoliaException):
     pass
+
+
+class ValidUntilNotFoundException(AlgoliaException):
+    pass

--- a/algoliasearch/search_client.py
+++ b/algoliasearch/search_client.py
@@ -1,9 +1,12 @@
 import base64
 import hashlib
 import hmac
+import re
+import time
 
 from typing import Optional, Union, List
 
+from algoliasearch.exceptions import ValidUntilNotFoundException
 from algoliasearch.helpers import endpoint, is_async_available
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.serializer import QueryParametersSerializer
@@ -301,6 +304,21 @@ class SearchClient(object):
         )
 
         return str(base64encoded.decode('utf-8'))
+
+    @staticmethod
+    def get_secured_api_key_remaining_validity(api_key):
+        # type: (str) -> int
+
+        decoded_string = base64.b64decode(api_key)
+
+        match = re.search(r'validUntil=(\d+)', str(decoded_string))
+
+        if match is None:
+            raise ValidUntilNotFoundException(
+                'ValidUntil not found in api key.'
+            )
+
+        return int(match.group(1)) - int(round(time.time()))
 
     def list_indices(self, request_options=None):
         # type: (Optional[Union[dict, RequestOptions]]) -> dict

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -38,7 +38,7 @@ class TestSearchIndex(unittest.TestCase):
             indexExists = self.index.exists()
 
             self.index.get_settings.assert_called_once()
-            self.assertEqual(indexExists, False);
+            self.assertEqual(indexExists, False)
 
     def test_index_exist_raises_non_4O4_exceptions(self):
         with mock.patch.object(self.index, 'get_settings') as submethod_mock:
@@ -59,7 +59,7 @@ class TestSearchIndex(unittest.TestCase):
             indexExists = self.index.exists()
 
             self.index.get_settings.assert_called_once()
-            self.assertEqual(indexExists, True);
+            self.assertEqual(indexExists, True)
 
     def test_save_objects(self):
         # Saving an object without object id


### PR DESCRIPTION
This pull request adds `get_secured_api_key_remaining_validity ` as specified on the api client specs.

closes #443