### PR TITLE
test: add userData to test_settings for CTS test

### DIFF
--- a/tests/helpers/misc.py
+++ b/tests/helpers/misc.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 from algoliasearch.exceptions import RequestException
@@ -24,3 +25,12 @@ class RetryableClient:
             return result
 
         return closure
+
+
+class Unicode:
+
+    @staticmethod
+    def convert_dict_to_unicode(d):
+        tmp = json.dumps(d)
+        tmp = json.loads(tmp)
+        return tmp


### PR DESCRIPTION
**Summary**
Set `userData` in the Settings test in the CTS. Because the Settings test was not fully implemented, this commit also implements the test with all the missing fields.