### PR TITLE
Update syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ from algoliasearch.search_client import SearchClient
 client = SearchClient.create('YourApplicationID', 'YourAPIKey')
 index = client.init_index('your_index_name')
 
-index.save_objects(['objectID': 1, 'name': 'Foo'])
+index.save_objects([{'objectID': 1, 'name': 'Foo'}])
 ```
 
 Finally, you may begin searching a object using the `search` method:


### PR DESCRIPTION
`save_objects` expects a list of (`dict`) objects.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Fix syntax error in README code example.

## What problem is this fixing?

`save_objects` expects a list of (`dict`) objects.
