### PR TITLE
fix(safe-replace-all-objects): blocking operation on save temporary objects

### DIFF
--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -115,8 +115,13 @@ class SearchIndex(object):
         if safe:
             responses.wait()
 
-        tmp_index = copy.copy(self)
-        tmp_index._name = tmp_index_name
+        try:
+            from algoliasearch.search_client import SearchClient
+        except ImportError:  # Already imported.
+            pass
+
+        tmp_client = SearchClient(self._transporter, self._config)
+        tmp_index = tmp_client.init_index(tmp_index_name)
 
         responses.push(tmp_index.save_objects(objects, request_options))
 

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -763,6 +763,25 @@ class TestSearchIndex(unittest.TestCase):
         # Check that synonym with objectID="two" does exist using getSynonym
         self.assertEqual(self.index.get_synonym('two')['objectID'], 'two')
 
+    def test_safe_replacing(self):
+
+        # Adds dummy object
+        self.index.save_object(F.obj()).wait()
+
+        # Calls replace all objects with an object without
+        # object id, and with the safe parameter
+        self.index.replace_all_objects([{'name': 'two'}], {
+            'autoGenerateObjectIDIfNotExist': True,
+            'safe': True
+        })
+
+        response = self.index.search('')
+        self.assertEqual(response['nbHits'], 1)
+        hit = response['hits'][0]
+        self.assertEqual(hit['name'], 'two')
+        self.assertIn('objectID', hit)
+        self.assertIn('_highlightResult', hit)
+
     def test_exists(self):
         self.assertFalse(self.index.exists())
         self.index.save_object(F.obj()).wait()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no

This pull request fixes the fact that the replace all objects could get blocked on the replace all objects method while using `safe` parameter with async dependencies.