### PR TITLE
fix: SearchIndex.replace_all_objects is stuck when using "safe" mode

### DIFF
--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -115,8 +115,7 @@ class SearchIndex(object):
         if safe:
             responses.wait()
 
-        tmp_index = copy.copy(self)
-        tmp_index._name = tmp_index_name
+        tmp_index = SearchIndex(self._transporter, self._config, tmp_index_name)
 
         responses.push(tmp_index.save_objects(objects, request_options))
 

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -763,6 +763,24 @@ class TestSearchIndex(unittest.TestCase):
         # Check that synonym with objectID="two" does exist using getSynonym
         self.assertEqual(self.index.get_synonym('two')['objectID'], 'two')
 
+    def test_safe_replacing(self):
+        # Adds dummy object
+        self.index.save_object(F.obj()).wait()
+
+        # Calls replace all objects with an object without
+        # object id, and with the safe parameter
+        self.index.replace_all_objects([{'name': 'two'}], {
+            'autoGenerateObjectIDIfNotExist': True,
+            'safe': True
+        })
+
+        response = self.index.search('')
+        self.assertEqual(response['nbHits'], 1)
+        hit = response['hits'][0]
+        self.assertEqual(hit['name'], 'two')
+        self.assertIn('objectID', hit)
+        self.assertIn('_highlightResult', hit)
+
     def test_exists(self):
         self.assertFalse(self.index.exists())
         self.index.save_object(F.obj()).wait()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #481
| Need Doc update   | no

## Describe your change

create new SearchIndex instance when creating a temporary index in replace_all_objects

as per doc: https://www.algolia.com/doc/api-reference/api-methods/replace-all-objects/,

when replacing all objects, a temporary index is used to store new data, and once ready it
replace the original index.

There was an issue when `replace_all_objects` was called with 'safe' move:
- when copying the existing index, and only replacing the index name, the
  name of `_search_index` (from SearchIndexAsync constructor) was not replaced
  with the temporary index name (`tmp_index_name`)
- after that, when tracking the task progress in `IndexingResponse.wait` the original
  index name from `_search_index` was used instead of the `tmp_index_name`

## What problem is this fixing?

Although it was working before, when tracked using the wrong index name,
the indexing task is stuck with status `notPublished`. (maybe it's something that should
also be fixed on the backend ?)

With this patch, instead of trying to patch `SearchIndex` copied instance, we create a
new clean instance.

When updating a "dev" index, previous call history would be:

```
# save_objects calls
--> POST 1/indexes/dev_tmp_aNCOSqmzOQ/batch {'requests': [{'action': 'updateObject', 'body': ... }]}
<-- 200 / {'objectIDs': ['obj_1', ...], 'taskID': 81739652001}

# track task progress in wait call

--> GET 1/indexes/dev/task/81739652001 None
<-- 200 / {'status': 'notPublished', 'pendingTask': False}
--> GET 1/indexes/dev/task/81739652001 None
<-- 200 / {'status': 'notPublished', 'pendingTask': False}

[ ... ] forever
```

after the fix the task is tracked on the correct index:

```
# save_objects calls
--> POST 1/indexes/dev_tmp_aNCOSqmzOQ/batch {'requests': [{'action': 'updateObject', 'body': ... }]}
<-- 200 / {'objectIDs': ['obj_1', ...], 'taskID': 81739652001}

# track task progress in wait call

--> GET 1/indexes/dev_tmp_aNCOSqmzOQ/task/81739652001 None
<-- 200 / {'status': 'notPublished', 'pendingTask': False}
--> GET 1/indexes/dev_tmp_aNCOSqmzOQ/task/81739652001 None
<-- 200 / {'status': 'notPublished', 'pendingTask': False}

[ ... ]

--> GET 1/indexes/dev_tmp_aNCOSqmzOQ/task/81739652001 None
<-- 200 / {'status': 'published', 'pendingTask': False}

```




