### PR TITLE
fix(blocked-replace-all-objects): do not share same client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-python/compare/v2.2.0...master)
 
 ### Fixed
-- Replace all objects could get blocked on the replace all objects method while using safe parameter with async dependencies. ([#479](https://github.com/algolia/algoliasearch-client-python/pull/479))
+- Replace all objects could get blocked on the replace all objects method while using safe parameter with async dependencies. ([#479](https://github.com/algolia/algoliasearch-client-python/pull/479), [493](https://github.com/algolia/algoliasearch-client-python/pull/493))
 
 ## [v2.2.0](https://github.com/algolia/algoliasearch-client-python/compare/2.1.0...2.2.0)
 

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -169,8 +169,9 @@ class SearchIndexAsync(SearchIndex):
         if safe:
             responses.wait()
 
+        tmp_client = SearchClient(self._transporter, self._config)
         tmp_index = SearchIndexAsync(
-            self._search_index,
+            tmp_client.init_index(tmp_index_name),
             self._transporter_async,
             self._config,
             tmp_index_name

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -13,6 +13,7 @@ from algoliasearch.http.serializer import SettingsDeserializer
 from algoliasearch.http.transporter_async import TransporterAsync
 from algoliasearch.http.verb import Verb
 from algoliasearch.responses import MultipleResponse
+from algoliasearch.search_client import SearchClient
 from algoliasearch.search_index import SearchIndex
 from algoliasearch.iterators_async import (
     ObjectIteratorAsync,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | fixes #481
| Need Doc update   | no

## Describe your change

Just like https://github.com/algolia/algoliasearch-client-python/pull/479 ensured we have a safe and new client for the replace all objects in sync mode. This pull request ensures the same thing for the async mode.
