### PR TITLE
fix(setup-cfg): invalid format in python requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ packages = find:
 install_requires =
     requests>=2.21,<3.0
     typing>=3.6,<4.0;python_version<"3.5"
-python_requires = >=2.7, !=3.0.*, !=3.1.*', !=3.2.*, !=3.3.*'
+python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, !=3.3.*
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | #499 

## What problem is this fixing?

This pull request fixes the invalid format used on the `setup.cfg` -> `python_requires` line.