### PR TITLE
Feat/support proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-python/compare/v2.3.1...master)
 
+### Added
+- Bring support for HTTP_PROXY / HTTPS_PROXY ([#505](https://github.com/algolia/algoliasearch-client-python/pull/505))
+
 ## [v2.3.1](https://github.com/algolia/algoliasearch-client-python/compare/v2.3.0...v2.3.1)
 
 ### Fixed
@@ -16,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.3.0](https://github.com/algolia/algoliasearch-client-python/compare/v2.2.0...v2.3.0)
 
 ### Added
-- Closeable http sessions directly from the clients ([492](https://github.com/algolia/algoliasearch-client-python/pull/492))
+- Closeable http sessions directly from the clients ([#492](https://github.com/algolia/algoliasearch-client-python/pull/492))
 
 ### Fixed
 - Replace all objects could get blocked on the replace all objects method while using safe parameter with async dependencies. ([#479](https://github.com/algolia/algoliasearch-client-python/pull/479), [493](https://github.com/algolia/algoliasearch-client-python/pull/493))

--- a/algoliasearch/configs.py
+++ b/algoliasearch/configs.py
@@ -40,6 +40,15 @@ class Config(object):
             'Content-Type': 'application/json',
         }
 
+        self.proxies = {
+            'http': os.environ.get("HTTP_PROXY"),
+            'https': os.environ.get("HTTPS_PROXY"),
+        }
+        if self.proxies['http'] is None:
+            del self.proxies['http']
+        if self.proxies['https'] is None:
+            del self.proxies['https']
+
     @abc.abstractmethod
     def build_hosts(self):
         # type: () -> HostsCollection

--- a/algoliasearch/exceptions.py
+++ b/algoliasearch/exceptions.py
@@ -19,6 +19,21 @@ class RequestException(AlgoliaException):
 
         super(AlgoliaException, self).__init__(message)
         self.status_code = status_code
+        self.message = message
+
+    def __hash__(self):
+        # type: () -> int
+        return id(self)
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        if isinstance(other, RequestException):
+            return (self.message == other.message and self.status_code == other.status_code)  # noqa: E501
+        return False
+
+    def __ne__(self, other):
+        # type: (object) -> bool
+        return not self.__eq__(other)
 
 
 class AlgoliaUnreachableHostException(AlgoliaException):

--- a/algoliasearch/http/requester.py
+++ b/algoliasearch/http/requester.py
@@ -37,7 +37,7 @@ class Requester(object):
 
         try:
             response = self._session.send(  # type: ignore
-                r, timeout=requests_timeout
+                r, timeout=requests_timeout, proxies=request.proxies,
             )
         except Timeout as e:
             return Response(error_message=str(e), is_timed_out_error=True)

--- a/algoliasearch/http/requester_async.py
+++ b/algoliasearch/http/requester_async.py
@@ -23,12 +23,19 @@ class RequesterAsync(Requester):
             self._session = aiohttp.ClientSession(  # type: ignore
                 connector=connector)
 
+        proxy = None
+        if request.url.startswith('https'):
+            proxy = request.proxies.get('https')
+        elif request.url.startswith('http'):
+            proxy = request.proxies.get('http')
+
         try:
             with async_timeout.timeout(request.timeout):
                 response = yield from (self._session.request(  # type: ignore
                     method=request.verb, url=request.url,
                     headers=request.headers,
-                    data=request.data_as_string
+                    data=request.data_as_string,
+                    proxy=proxy
                 ))
 
                 json = yield from response.json()

--- a/algoliasearch/http/transporter.py
+++ b/algoliasearch/http/transporter.py
@@ -69,8 +69,14 @@ class Transporter(object):
                                           query_parameters
                                       ))
 
-        request = Request(verb.upper(), request_options.headers, data,
-                          self._config.connect_timeout, timeout)
+        request = Request(
+            verb.upper(),
+            request_options.headers,
+            data,
+            self._config.connect_timeout,
+            timeout,
+            self._config.proxies,
+        )
 
         return self.retry(hosts, request, relative_url)
 
@@ -104,8 +110,8 @@ class Transporter(object):
 
 
 class Request(object):
-    def __init__(self, verb, headers, data, connect_timeout, timeout):
-        # type: (str, dict, Optional[Union[dict, list]], int, int) -> None
+    def __init__(self, verb, headers, data, connect_timeout, timeout, proxies={}):  # noqa: E501
+        # type: (str, dict, Optional[Union[dict, list]], int, int, dict) -> None  # noqa: E501
 
         self.verb = verb
         self.data = data
@@ -115,6 +121,7 @@ class Request(object):
         self.headers = headers
         self.connect_timeout = connect_timeout
         self.timeout = timeout
+        self.proxies = proxies
         self.url = ''
 
     def __str__(self):

--- a/algoliasearch/http/transporter.py
+++ b/algoliasearch/http/transporter.py
@@ -117,6 +117,20 @@ class Request(object):
         self.timeout = timeout
         self.url = ''
 
+    def __str__(self):
+        return 'Request({}, {}, {}, {}, {}, {}, {})'.format(
+            self.verb,
+            self.url,
+            self.headers,
+            self.data_as_string,
+            self.connect_timeout,
+            self.timeout,
+            self.proxies,
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
     def __eq__(self, other):
         # type: (object) -> bool
 

--- a/tests/features/test_recommendation_client.py
+++ b/tests/features/test_recommendation_client.py
@@ -2,6 +2,7 @@ import unittest
 
 from tests.helpers.env import Env
 from tests.helpers.factory import Factory as F
+from algoliasearch.exceptions import RequestException
 
 
 class TestRecommendationClient(unittest.TestCase):
@@ -34,14 +35,16 @@ class TestRecommendationClient(unittest.TestCase):
             'personalizationImpact': 0,
         }
 
-        response = self.client.set_personalization_strategy(
-            personalization_strategy
-        )
-
-        self.assertEqual(response, {
-            'status': 200,
-            'message': 'Strategy was successfully updated'
-        })
+        try:
+            response = self.client.set_personalization_strategy(
+                personalization_strategy
+            )
+            self.assertEqual(response, {
+                'status': 200,
+                'message': 'Strategy was successfully updated'
+            })
+        except RequestException as err:
+            self.assertEqual(err, RequestException('Number of strategy saves exceeded for the day', 429))  # noqa: E501
 
         response = self.client.get_personalization_strategy()
         self.assertEqual(response, personalization_strategy)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | N/A
| Need Doc update   | no

## Summary

This commit brings support for user-defined proxy addresses, defined by
the `HTTP_PROXY` or `HTTPS_PROXY` environment variables, or via the
`Config.proxies` dictionnary of the form:

```py
Config.proxies = {
    'http: 'https://127.0.0.1:8080',
    'https: 'https://127.0.0.1:8080',
}
```

This works for both the `Requester` and the `RequesterAsync`.