### PR TITLE
fix: accept X-Algolia-UserToken as a valid extra header for RequestOptions

### DIFF
--- a/algoliasearch/http/request_options.py
+++ b/algoliasearch/http/request_options.py
@@ -51,7 +51,13 @@ class RequestOptions(object):
 
 
 class Params(object):
-    HEADERS = ("Content-type", "User-Agent", "X-Algolia-User-ID", "X-Forwarded-For")
+    HEADERS = (
+        "Content-type",
+        "User-Agent",
+        "X-Algolia-User-ID",
+        "X-Algolia-UserToken",
+        "X-Forwarded-For",
+    )
 
     QUERY_PARAMETERS = (
         "createIfNotExists",


### PR DESCRIPTION
Needed for doc snippets here: https://github.com/algolia/doc/pull/4737