### PR TITLE
fix: remove password and username on the legacy command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,4 +70,4 @@ passenv =
 commands =
     python setup.py sdist bdist_wheel
     twine check dist/*
-    twine upload --username $PYPI_USER --password $PYPI_PASSWORD dist/*
+    twine upload dist/*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | DX-1899
| Need Doc update   | yes/no


## Describe your change

Update the release process : 

- Upload on TestPIPY before release on PIPY
- Upload on TestPIPY without specifying credentials because twine use  keyring which look into env variable.

## What problem is this fixing?

Automatic release wasn't working because we were trying to release without proper credentials
