### PR TITLE
feat(AnswersClient): V1 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # Release Notes
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-python/compare/v2.5.0...master)
+- Add support for Answers API [#528](https://github.com/algolia/algoliasearch-client-python/pull/528)
 
 ## [v2.5.0](https://github.com/algolia/algoliasearch-client-python/compare/v2.4.0...v2.5.0)
 

--- a/algoliasearch/answers_client.py
+++ b/algoliasearch/answers_client.py
@@ -37,14 +37,15 @@ class AnswersClient(object):
             from algoliasearch.http.transporter_async import TransporterAsync
             from algoliasearch.http.requester_async import RequesterAsync
 
-           return AnswersClientAsync(
-               client, TransporterAsync(RequesterAsync(), config), config
-           )
+            return AnswersClientAsync(
+                client, TransporterAsync(RequesterAsync(), config), config
+            )
+
         return client
 
     def predict(
         self, index_name, answers_parameters, request_options=None
-    ):
+    ):  # noqa: E501
         # type: (str, dict, Optional[Union[dict, RequestOptions]]) -> dict
 
         return self._transporter.write(

--- a/algoliasearch/answers_client.py
+++ b/algoliasearch/answers_client.py
@@ -1,0 +1,63 @@
+from typing import Optional, Union, Dict, Any
+
+from algoliasearch.configs import AnswersConfig
+from algoliasearch.helpers import is_async_available
+from algoliasearch.http.request_options import RequestOptions
+from algoliasearch.http.requester import Requester
+from algoliasearch.http.transporter import Transporter
+from algoliasearch.http.verb import Verb
+
+
+class AnswersClient(object):
+    def __init__(self, transporter, config):
+        # type: (Transporter, AnswersConfig) -> None
+
+        self._transporter = transporter
+        self._config = config
+
+    @staticmethod
+    def create(app_id=None, api_key=None):
+        # type: (Optional[str], Optional[str]) -> AnswersClient  # noqa: E501
+
+        config = AnswersConfig(app_id, api_key)
+
+        return AnswersClient.create_with_config(config)
+
+    @staticmethod
+    def create_with_config(config):
+        # type: (AnswersConfig) -> AnswersClient
+
+        requester = Requester()
+        transporter = Transporter(requester, config)
+
+        client = AnswersClient(transporter, config)
+
+        if is_async_available():
+            from algoliasearch.answers_client_async import (
+                AnswersClientAsync,
+            )
+            from algoliasearch.http.transporter_async import TransporterAsync
+            from algoliasearch.http.requester_async import RequesterAsync
+
+            return AnswersClientAsync(
+                client, TransporterAsync(RequesterAsync(), config), config
+            )
+
+        return client
+
+    def predict(
+        self, index_name, answers_parameters, request_options=None
+    ):  # noqa: E501
+        # type: (str, dict, Optional[Union[dict, RequestOptions]]) -> dict
+
+        return self._transporter.write(
+            Verb.POST,
+            "1/answers/{}/prediction".format(index_name),
+            answers_parameters,
+            request_options,
+        )
+
+    def close(self):
+        # type: () -> None
+
+        return self._transporter.close()  # type: ignore

--- a/algoliasearch/answers_client.py
+++ b/algoliasearch/answers_client.py
@@ -33,17 +33,18 @@ class AnswersClient(object):
         client = AnswersClient(transporter, config)
 
         if is_async_available():
-            from algoliasearch.answers_client_async import (
-                AnswersClientAsync,
-            )
+            from algoliasearch.answers_client_async import AnswersClientAsync
             from algoliasearch.http.transporter_async import TransporterAsync
             from algoliasearch.http.requester_async import RequesterAsync
 
-            return AnswersClientAsync(client, TransporterAsync(RequesterAsync(), config), config)
-
+           return AnswersClientAsync(
+               client, TransporterAsync(RequesterAsync(), config), config
+           )
         return client
 
-    def predict(self, index_name, answers_parameters, request_options=None):  # noqa: E501
+    def predict(
+        self, index_name, answers_parameters, request_options=None
+    ):
         # type: (str, dict, Optional[Union[dict, RequestOptions]]) -> dict
 
         return self._transporter.write(

--- a/algoliasearch/answers_client.py
+++ b/algoliasearch/answers_client.py
@@ -39,15 +39,11 @@ class AnswersClient(object):
             from algoliasearch.http.transporter_async import TransporterAsync
             from algoliasearch.http.requester_async import RequesterAsync
 
-            return AnswersClientAsync(
-                client, TransporterAsync(RequesterAsync(), config), config
-            )
+            return AnswersClientAsync(client, TransporterAsync(RequesterAsync(), config), config)
 
         return client
 
-    def predict(
-        self, index_name, answers_parameters, request_options=None
-    ):  # noqa: E501
+    def predict(self, index_name, answers_parameters, request_options=None):  # noqa: E501
         # type: (str, dict, Optional[Union[dict, RequestOptions]]) -> dict
 
         return self._transporter.write(

--- a/algoliasearch/answers_client_async.py
+++ b/algoliasearch/answers_client_async.py
@@ -14,7 +14,9 @@ class AnswersClientAsync(AnswersClient):
 
         self._transporter_async = transporter
 
-        super(AnswersClientAsync, self).__init__(answers_client._transporter, search_config)
+        super(AnswersClientAsync, self).__init__(
+            answers_client._transporter, search_config
+        )
 
         client = AnswersClient(transporter, search_config)
 

--- a/algoliasearch/answers_client_async.py
+++ b/algoliasearch/answers_client_async.py
@@ -14,9 +14,7 @@ class AnswersClientAsync(AnswersClient):
 
         self._transporter_async = transporter
 
-        super(AnswersClientAsync, self).__init__(
-            answers_client._transporter, search_config
-        )
+        super(AnswersClientAsync, self).__init__(answers_client._transporter, search_config)
 
         client = AnswersClient(transporter, search_config)
 

--- a/algoliasearch/answers_client_async.py
+++ b/algoliasearch/answers_client_async.py
@@ -1,0 +1,43 @@
+import types
+import asyncio
+from typing import Optional, Type
+
+from algoliasearch.answers_client import AnswersClient
+from algoliasearch.configs import AnswersConfig
+from algoliasearch.helpers_async import _create_async_methods_in
+from algoliasearch.http.transporter_async import TransporterAsync
+
+
+class AnswersClientAsync(AnswersClient):
+    def __init__(self, answers_client, transporter, search_config):
+        # type: (AnswersClient, TransporterAsync, AnswersConfig) -> None # noqa: E501
+
+        self._transporter_async = transporter
+
+        super(AnswersClientAsync, self).__init__(
+            answers_client._transporter, search_config
+        )
+
+        client = AnswersClient(transporter, search_config)
+
+        _create_async_methods_in(self, client)
+
+    @asyncio.coroutine
+    def __aenter__(self):
+        # type: () -> AnswersClientAsync # type: ignore
+
+        return self  # type: ignore
+
+    @asyncio.coroutine
+    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+        # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
+
+        yield from self.close_async()  # type: ignore
+
+    @asyncio.coroutine
+    def close_async(self):  # type: ignore
+        # type: () -> None
+
+        super().close()
+
+        yield from self._transporter_async.close()  # type: ignore

--- a/algoliasearch/configs.py
+++ b/algoliasearch/configs.py
@@ -89,9 +89,7 @@ class AnalyticsConfig(Config):
     def build_hosts(self):
         # type: () -> HostsCollection
 
-        return HostsCollection(
-            [Host("{}.{}.{}".format("analytics", self._region, "algolia.com"))]
-        )
+        return HostsCollection([Host("{}.{}.{}".format("analytics", self._region, "algolia.com"))])
 
 
 class InsightsConfig(Config):
@@ -105,9 +103,7 @@ class InsightsConfig(Config):
     def build_hosts(self):
         # type: () -> HostsCollection
 
-        return HostsCollection(
-            [Host("{}.{}.{}".format("insights", self._region, "algolia.io"))]
-        )
+        return HostsCollection([Host("{}.{}.{}".format("insights", self._region, "algolia.io"))])
 
 
 class RecommendationConfig(Config):
@@ -121,9 +117,8 @@ class RecommendationConfig(Config):
     def build_hosts(self):
         # type: () -> HostsCollection
 
-        return HostsCollection(
-            [Host("{}.{}.{}".format("recommendation", self._region, "algolia.com"))]
-        )
+        return HostsCollection([Host("{}.{}.{}".format("recommendation", self._region, "algolia.com"))])
+
 
 class AnswersConfig(SearchConfig):
     def __init__(self, app_id=None, api_key=None):

--- a/algoliasearch/configs.py
+++ b/algoliasearch/configs.py
@@ -103,7 +103,9 @@ class InsightsConfig(Config):
     def build_hosts(self):
         # type: () -> HostsCollection
 
-        return HostsCollection([Host("{}.{}.{}".format("insights", self._region, "algolia.io"))])
+        return HostsCollection(
+            [Host("{}.{}.{}".format("insights", self._region, "algolia.io"))]
+        )
 
 
 class RecommendationConfig(Config):
@@ -117,7 +119,9 @@ class RecommendationConfig(Config):
     def build_hosts(self):
         # type: () -> HostsCollection
 
-        return HostsCollection([Host("{}.{}.{}".format("recommendation", self._region, "algolia.com"))])
+        return HostsCollection(
+            [Host("{}.{}.{}".format("recommendation", self._region, "algolia.com"))]
+        )
 
 
 class AnswersConfig(SearchConfig):

--- a/algoliasearch/configs.py
+++ b/algoliasearch/configs.py
@@ -124,3 +124,9 @@ class RecommendationConfig(Config):
         return HostsCollection(
             [Host("{}.{}.{}".format("recommendation", self._region, "algolia.com"))]
         )
+
+class AnswersConfig(SearchConfig):
+    def __init__(self, app_id=None, api_key=None):
+        # type: (Optional[str], Optional[str]) -> None
+
+        super(AnswersConfig, self).__init__(app_id, api_key)

--- a/algoliasearch/configs.py
+++ b/algoliasearch/configs.py
@@ -89,7 +89,9 @@ class AnalyticsConfig(Config):
     def build_hosts(self):
         # type: () -> HostsCollection
 
-        return HostsCollection([Host("{}.{}.{}".format("analytics", self._region, "algolia.com"))])
+        return HostsCollection(
+            [Host("{}.{}.{}".format("analytics", self._region, "algolia.com"))]
+        )
 
 
 class InsightsConfig(Config):

--- a/tests/features/test_answers_client.py
+++ b/tests/features/test_answers_client.py
@@ -13,7 +13,7 @@ class TestAnswersClient(unittest.TestCase):
             [
                 {
                     "name": "Something",
-                    "description": "Your usage of demo datasets is usually more creative :')",
+                    "description": "The usage is strong in that one",
                     "objectID": 0,
                 },
                 {

--- a/tests/features/test_answers_client.py
+++ b/tests/features/test_answers_client.py
@@ -9,17 +9,20 @@ class TestAnswersClient(unittest.TestCase):
         self.search_client = F.search_client()
         self.client = F.answers_client()
         self.index = F.index(self.search_client, self._testMethodName)
-        self.index.save_objects([
-            {
-                "name": "Something",
-                "description": "Your usage of demo datasets is usually more creative :')",
-                "objectID": 0,
-            }, {
-                "name": "Another thing",
-                "description": "This is creative, but unused. ;)",
-                "objectID": 1,
-            },
-        ]).wait()
+        self.index.save_objects(
+            [
+                {
+                    "name": "Something",
+                    "description": "Your usage of demo datasets is usually more creative :')",
+                    "objectID": 0,
+                },
+                {
+                    "name": "Another thing",
+                    "description": "This is creative, but unused. ;)",
+                    "objectID": 1,
+                },
+            ]
+        ).wait()
 
     def tearDown(self):
         self.client.close()
@@ -29,7 +32,7 @@ class TestAnswersClient(unittest.TestCase):
             "query": "Any usage?",
             "queryLanguages": ["en"],
             "attributesForPrediction": ["title", "description"],
-            "nbHits": 2
+            "nbHits": 2,
         }
 
         try:

--- a/tests/features/test_answers_client.py
+++ b/tests/features/test_answers_client.py
@@ -1,0 +1,42 @@
+import unittest
+
+from algoliasearch.exceptions import RequestException
+from tests.helpers.factory import Factory as F
+
+
+class TestAnswersClient(unittest.TestCase):
+    def setUp(self):
+        self.search_client = F.search_client()
+        self.client = F.answers_client()
+        self.index = F.index(self.search_client, self._testMethodName)
+        self.index.save_objects([
+            {
+                "name": "Something",
+                "description": "Your usage of demo datasets is usually more creative :')",
+                "objectID": 0,
+            }, {
+                "name": "Another thing",
+                "description": "This is creative, but unused. ;)",
+                "objectID": 1,
+            },
+        ]).wait()
+
+    def tearDown(self):
+        self.client.close()
+
+    def test_answers(self):
+        data = {
+            "query": "Any usage?",
+            "queryLanguages": ["en"],
+            "attributesForPrediction": ["title", "description"],
+            "nbHits": 2
+        }
+
+        try:
+            response = self.client.predict(self.index.name, data)
+            print(response)
+            self.assertTrue("hits" in response)
+            self.assertIn("usage", response["hits"][0]["_answer"]["extract"])
+            self.assertEqual("0", response["hits"][0]["objectID"])
+        except RequestException as err:
+            self.fail(err)  # noqa: E501

--- a/tests/helpers/factory.py
+++ b/tests/helpers/factory.py
@@ -8,6 +8,7 @@ from random import shuffle
 from typing import Optional
 
 from algoliasearch.analytics_client import AnalyticsClient
+from algoliasearch.answers_client import AnswersClient
 from algoliasearch.insights_client import InsightsClient
 from algoliasearch.search_client import SearchClient, SearchConfig
 from algoliasearch.recommendation_client import RecommendationClient
@@ -86,6 +87,15 @@ class Factory(object):
         api_key = api_key if api_key is not None else Factory.get_api_key()
 
         return Factory.decide(RecommendationClient.create(app_id, api_key))
+
+    @staticmethod
+    def answers_client(app_id=None, api_key=None):
+        # type: (Optional[str], Optional[str]) -> AnswersClient
+
+        app_id = app_id if app_id is not None else Factory.get_app_id()
+        api_key = api_key if api_key is not None else Factory.get_api_key()
+
+        return Factory.decide(AnswersClient.create(app_id, api_key))
 
     @staticmethod
     def insights_client(app_id=None, api_key=None):


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| New feature?      | yes/no    <!-- please update the /CHANGELOG.md file -->
| Need Doc update   | yes


## Describe your change

Adds a first implementation of the [Answers API](https://www.algolia.com/doc/rest-api/answers/)'s `prediction` endpoint.

### Design considerations
- As the API is still in beta, this implem doesn't strongly type Answers parameters like `query`, `queryLanguages`, or `returnExtractAttribute` until these have a finalized status and naming.
- I made the `index` a parameter, to allow for the same `AnswersClient` to target different indices successively - can be reconsidered if it makes it inconsistent with this client's users' expectations.