### PR TITLE
fix(automatic-release): pass ENV variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,4 +74,4 @@ passenv =
 commands =
     python setup.py sdist bdist_wheel
     twine check dist/*
-    twine upload --username $PYPI_USER --password $PYPI_PASSWORD dist/*
+    twine upload -u {env:PYPI_USER} -p {env:PYPI_PASSWORD} --repository-url https://upload.pypi.org/legacy/ dist/*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fixes https://github.com/algolia/algoliasearch-client-python/pull/526
| Need Doc update   | no


## Describe your change

Env variables were not passed when inlined in twine CLI, it should now work as expected.

## What problem is this fixing?

Automatic release should now work
