### PR TITLE
fix(iterators): prevent recursion issue

### DIFF
--- a/algoliasearch/iterators.py
+++ b/algoliasearch/iterators.py
@@ -35,6 +35,8 @@ class Iterator(object):
 
 
 class PaginatorIterator(Iterator):
+    nbHits = 0
+
     def __init__(self, transporter, index_name, request_options=None):
         # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
@@ -57,7 +59,7 @@ class PaginatorIterator(Iterator):
 
                 return hit
 
-            if self._raw_response["nbHits"] < self._data["hitsPerPage"]:
+            if self.nbHits < self._data["hitsPerPage"]:
                 self._raw_response = {}
                 self._data = {
                     "hitsPerPage": 1000,
@@ -68,6 +70,7 @@ class PaginatorIterator(Iterator):
         self._raw_response = self._transporter.read(
             Verb.POST, self.get_endpoint(), self._data, self._request_options
         )
+        self.nbHits = len(self._raw_response["hits"])
 
         self._data["page"] += 1
 

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -10,6 +10,8 @@ from algoliasearch.iterators import Iterator
 
 
 class PaginatorIteratorAsync(Iterator):
+    nbHits = 0
+
     def __init__(self, transporter, index_name, request_options=None):
         # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
@@ -38,7 +40,7 @@ class PaginatorIteratorAsync(Iterator):
 
                 return hit
 
-            if self._raw_response["nbHits"] < self._data["hitsPerPage"]:
+            if self.nbHits < self._data["hitsPerPage"]:
                 self._raw_response = {}
                 self._data = {
                     "hitsPerPage": 1000,
@@ -49,6 +51,7 @@ class PaginatorIteratorAsync(Iterator):
         self._raw_response = yield from self._transporter.read(
             Verb.POST, self.get_endpoint(), self._data, self._request_options
         )
+        self.nbHits = len(self._raw_response["hits"])
 
         self._data["page"] += 1
 

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -14,6 +14,7 @@ from tests.helpers.factory import Factory as F
 from tests.helpers.misc import Unicode, rule_without_metadata
 from unittest.mock import MagicMock
 
+
 class TestSearchIndex(unittest.TestCase):
     def setUp(self):
         self.client = F.search_client()
@@ -456,7 +457,6 @@ class TestSearchIndex(unittest.TestCase):
         self.assertEqual(self.index.search_synonyms("")["nbHits"], 0)
 
     def test_browse_rules(self):
-
         def side_effect(req, **kwargs):
             hits = [{"objectID": i, "_highlightResult": None} for i in range(0, 1000)]
             page = json.loads(req.body)["page"]
@@ -467,12 +467,14 @@ class TestSearchIndex(unittest.TestCase):
             response = Response()
             response.status_code = 200
             response._content = str.encode(
-                json.dumps({
-                    "hits": hits,
-                    "nbHits": 3800,
-                    "page": page,
-                    "nbPages": 3,
-                })
+                json.dumps(
+                    {
+                        "hits": hits,
+                        "nbHits": 3800,
+                        "page": page,
+                        "nbPages": 3,
+                    }
+                )
             )
 
             return response


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Support ticket
| Need Doc update   | yes


## Describe your change

`if self._raw_response["nbHits"] < self._data["hitsPerPage"]:` was never validated since `nbHits` does not represent the number of returned hits but the total of hits.

We now compute `nbHits` on the `len(hits)`.

## What problem is this fixing?

Recursion was never ending with iterations > 1000 `hitsPerPage`. 

## Reproduction

I've set an index (`python_repro_rules`) with 3k+ rules on this app (`QPBQ67WNIG`)

```py
from algoliasearch.search_client import SearchClient, SearchConfig

config = SearchConfig('QPBQ67WNIG', 'SEARCH_API_KEY')
client = SearchClient.create_with_config(config)
index = client.init_index('python_repro_rules')

i = 0
for rule in index.browse_rules():
    print('called in main', i)
    i += 1

``` 