### PR TITLE
Add quick check to PaginatorIterator to check if the hits dictionary …

### DIFF
--- a/algoliasearch/iterators.py
+++ b/algoliasearch/iterators.py
@@ -55,7 +55,8 @@ class PaginatorIterator(Iterator):
             if len(self._raw_response["hits"]):
                 hit = self._raw_response["hits"].pop(0)
 
-                hit.pop("_highlightResult")
+                if ("_highlightResult" in hit):
+                    hit.pop("_highlightResult")
 
                 return hit
 


### PR DESCRIPTION
…contains the element '_highlightResult'

This is to avoid the iterators file throwing a KeyError when the element does not contain this.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #544 
| Need Doc update   | yes/no


## Describe your change

Checks if the hit element contains the key '_highlightResult' before removing it from the element.

## What problem is this fixing?

When batch saving rules called from the browse_rules API call, the RuleIterator throws a KeyError if the rule element does not contain the key '_highlightResult'. This is a rare occurrence but it is possible. 
