### PR TITLE
fix(iterators): encode path parameters

### DIFF
--- a/algoliasearch/http/requester.py
+++ b/algoliasearch/http/requester.py
@@ -4,7 +4,7 @@ import requests
 
 from requests import Timeout, RequestException, Session
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
+from urllib3.util import Retry
 
 from algoliasearch.http.transporter import Response, Request
 

--- a/algoliasearch/iterators.py
+++ b/algoliasearch/iterators.py
@@ -1,6 +1,7 @@
 import abc
 
 from typing import Optional, Union
+from algoliasearch.helpers import endpoint
 
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.transporter import Transporter
@@ -101,7 +102,7 @@ class ObjectIterator(Iterator):
 
         self._raw_response = self._transporter.read(
             Verb.POST,
-            "1/indexes/{}/browse".format(self._index_name),
+            endpoint("1/indexes/{}/browse", self._index_name),
             data,
             self._request_options,
         )
@@ -113,11 +114,11 @@ class SynonymIterator(PaginatorIterator):
     def get_endpoint(self):
         # type: () -> str
 
-        return "1/indexes/{}/synonyms/search".format(self._index_name)
+        return endpoint("1/indexes/{}/synonyms/search", self._index_name)
 
 
 class RuleIterator(PaginatorIterator):
     def get_endpoint(self):
         # type: () -> str
 
-        return "1/indexes/{}/rules/search".format(self._index_name)
+        return endpoint("1/indexes/{}/rules/search", self._index_name)

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 
 from typing import Optional, Union
+from algoliasearch.helpers import endpoint
 
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.transporter import Transporter
@@ -90,7 +91,7 @@ class ObjectIteratorAsync(Iterator):
 
         self._raw_response = yield from self._transporter.read(
             Verb.POST,
-            "1/indexes/{}/browse".format(self._index_name),
+            endpoint("1/indexes/{}/browse", self._index_name),
             data,
             self._request_options,
         )
@@ -102,11 +103,11 @@ class SynonymIteratorAsync(PaginatorIteratorAsync):
     def get_endpoint(self):
         # type: () -> str
 
-        return "1/indexes/{}/synonyms/search".format(self._index_name)
+        return endpoint("1/indexes/{}/synonyms/search", self._index_name)
 
 
 class RuleIteratorAsync(PaginatorIteratorAsync):
     def get_endpoint(self):
         # type: () -> str
 
-        return "1/indexes/{}/rules/search".format(self._index_name)
+        return endpoint("1/indexes/{}/rules/search", self._index_name)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -41,3 +41,8 @@ class TestHelpers(unittest.TestCase):
             "/1/indexes/%23index%20name_42%23%2523/batch",
             endpoint("/1/indexes/{}/batch", "#index name_42#%23"),
         )
+
+        self.assertEqual(
+            "/1/indexes/space%20bar/browse",
+            endpoint("/1/indexes/{}/browse", "space bar"),
+        )

--- a/tests/unit/test_search_index.py
+++ b/tests/unit/test_search_index.py
@@ -371,6 +371,51 @@ class TestSearchIndex(unittest.TestCase):
         with self.assertRaises(AssertionError) as _:
             self.index.get_task("")
 
+    def test_browse_objects_encode_path(self):
+        index = SearchIndex(self.transporter, self.config, "#index name_42#%23")
+        self.transporter.read.return_value = {"hits": [{"foo": "bar"}], "nbPages": 1}
+
+        index.browse_objects().next()
+
+        self.transporter.read.assert_called_once_with(
+            "POST",
+            "1/indexes/%23index%20name_42%23%2523/browse",
+            {},
+            None,
+        )
+
+    def test_browse_rules_encode_path(self):
+        index = SearchIndex(self.transporter, self.config, "#index name_42#%23")
+        self.transporter.read.return_value = {
+            "hits": [{"foo": "bar", "_highlightResult": "algolia"}],
+            "nbPages": 1,
+        }
+
+        index.browse_rules().next()
+
+        self.transporter.read.assert_called_once_with(
+            "POST",
+            "1/indexes/%23index%20name_42%23%2523/rules/search",
+            {"hitsPerPage": 1000, "page": 1},
+            None,
+        )
+
+    def test_browse_synonyms_encode_path(self):
+        index = SearchIndex(self.transporter, self.config, "#index name_42#%23")
+        self.transporter.read.return_value = {
+            "hits": [{"foo": "bar", "_highlightResult": "algolia"}],
+            "nbPages": 1,
+        }
+
+        index.browse_synonyms().next()
+
+        self.transporter.read.assert_called_once_with(
+            "POST",
+            "1/indexes/%23index%20name_42%23%2523/synonyms/search",
+            {"hitsPerPage": 1000, "page": 1},
+            None,
+        )
+
 
 class NullResponse(Response):
     def wait(self):

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ aiohttp = >=2.0,<4.0; python_version >= '3.4.2'
 async_timeout = >=2.0,<4.0
 mypy = >=0.6,<7.0
 flake8 = ==3.8.3
-black = ==20.8b0
+black = ==22.3.0
 twine = >=1.13,<2.0
 wheel = >=0.34,<1.0
 requests = ==2.26.0


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no
| Need Doc update   | no


## Describe your change

We now encode the path using the `endpoint` method (like we do in the Client transporter calls).

## What problem is this fixing?

Path parameters in the `iterators` were not encoded.
