### PR TITLE
Python: Add python 3.10 support and remove deprecated versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,27 +73,6 @@ workflows:
             tags:
               only: /.*/
       - test:
-          name: 'test_34'
-          docker_version: '3.4'
-          tox_version: '34'
-          filters:
-            tags:
-              only: /.*/
-      - test:
-          name: 'test_35'
-          docker_version: '3.5'
-          tox_version: '35'
-          filters:
-            tags:
-              only: /.*/
-      - test:
-          name: 'test_36'
-          docker_version: '3.6'
-          tox_version: '36'
-          filters:
-            tags:
-              only: /.*/
-      - test:
           name: 'test_37'
           docker_version: '3.7'
           tox_version: '37'
@@ -104,6 +83,20 @@ workflows:
           name: 'test_38'
           docker_version: '3.8'
           tox_version: '38'
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          name: 'test_39'
+          docker_version: '3.9'
+          tox_version: '39'
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          name: 'test_310'
+          docker_version: '3.10'
+          tox_version: '310'
           filters:
             tags:
               only: /.*/
@@ -120,11 +113,10 @@ workflows:
       - release:
           requires:
             - test_27
-            - test_34
-            - test_35
-            - test_36
             - test_37
             - test_38
+            - test_39
+            - test_310
             - format
             - types
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,6 @@ workflows:
   build:
     jobs:
       - test:
-          name: 'test_27'
-          docker_version: '2.7'
-          tox_version: '27'
-          filters:
-            tags:
-              only: /.*/
-      - test:
           name: 'test_37'
           docker_version: '3.7'
           tox_version: '37'
@@ -112,7 +105,6 @@ workflows:
               only: /.*/
       - release:
           requires:
-            - test_27
             - test_37
             - test_38
             - test_39

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## ✨ Features
 
 - Thin & minimal low-level HTTP client to interact with Algolia's API
-- Supports Python: `2.7`, [`3.7`-`3.10`]
+- Supports Python: [`3.7`-`3.10`]
 - Contains blazing-fast asynchronous methods built on top of the [Asyncio](https://docs.python.org/3/library/asyncio.html)
 
 ## 💡 Getting Started

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## ✨ Features
 
 - Thin & minimal low-level HTTP client to interact with Algolia's API
-- Supports Python: `2.7`, `3.4`, `3.5`, `3.6`, `3.7`, and `3.8`
+- Supports Python: `2.7`, [`3.7`-`3.10`]
 - Contains blazing-fast asynchronous methods built on top of the [Asyncio](https://docs.python.org/3/library/asyncio.html)
 
 ## 💡 Getting Started
@@ -59,7 +59,7 @@ For full documentation, visit the **[Algolia Python API Client](https://www.algo
 
 Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://www.algolia.com/doc/api-client/troubleshooting/faq/python/) where you will find answers for the most common issues and gotchas with the client.
 
-## Use the Dockerfile
+## ⚙️ Use the Dockerfile
 
 If you want to contribute to this project without installing all its dependencies, you can use our Docker image. Please check our [dedicated guide](DOCKER_README.MD) to learn more.
 

--- a/algoliasearch/account_client.py
+++ b/algoliasearch/account_client.py
@@ -6,7 +6,7 @@ from algoliasearch.responses import MultipleResponse
 from algoliasearch.search_index import SearchIndex
 
 
-class AccountClient(object):
+class AccountClient:
     @staticmethod
     def copy_index(source_index, destination_index, request_options=None):
         # type: (SearchIndex, SearchIndex, Optional[Union[Dict[str, Any], RequestOptions]]) -> MultipleResponse  # noqa: E501

--- a/algoliasearch/analytics_client.py
+++ b/algoliasearch/analytics_client.py
@@ -8,7 +8,7 @@ from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.verb import Verb
 
 
-class AnalyticsClient(object):
+class AnalyticsClient:
     def __init__(self, transporter, search_config):
         # type: (Transporter, AnalyticsConfig) -> None
 

--- a/algoliasearch/analytics_client_async.py
+++ b/algoliasearch/analytics_client_async.py
@@ -15,7 +15,7 @@ class AnalyticsClientAsync(AnalyticsClient):
 
         self._transporter_async = transporter
 
-        super(AnalyticsClientAsync, self).__init__(
+        super().__init__(
             analytics_client._transporter, search_config
         )
 

--- a/algoliasearch/configs.py
+++ b/algoliasearch/configs.py
@@ -8,7 +8,7 @@ from algoliasearch.http.hosts import Host, HostsCollection, CallType
 from algoliasearch.user_agent import UserAgent
 
 
-class Config(object):
+class Config:
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, app_id=None, api_key=None):
@@ -60,7 +60,7 @@ class SearchConfig(Config):
     def __init__(self, app_id=None, api_key=None):
         # type: (Optional[str], Optional[str]) -> None
 
-        super(SearchConfig, self).__init__(app_id, api_key)
+        super().__init__(app_id, api_key)
 
         self.batch_size = 1000
 
@@ -69,11 +69,11 @@ class SearchConfig(Config):
 
         return HostsCollection(
             [
-                Host("{}-dsn.algolia.net".format(self.app_id), 10, CallType.READ),
-                Host("{}.algolia.net".format(self.app_id), 10, CallType.WRITE),
-                Host("{}-1.algolianet.com".format(self.app_id)),
-                Host("{}-2.algolianet.com".format(self.app_id)),
-                Host("{}-3.algolianet.com".format(self.app_id)),
+                Host(f"{self.app_id}-dsn.algolia.net", 10, CallType.READ),
+                Host(f"{self.app_id}.algolia.net", 10, CallType.WRITE),
+                Host(f"{self.app_id}-1.algolianet.com"),
+                Host(f"{self.app_id}-2.algolianet.com"),
+                Host(f"{self.app_id}-3.algolianet.com"),
             ]
         )
 
@@ -84,7 +84,7 @@ class AnalyticsConfig(Config):
 
         self._region = "us" if region is None else region
 
-        super(AnalyticsConfig, self).__init__(app_id, api_key)
+        super().__init__(app_id, api_key)
 
     def build_hosts(self):
         # type: () -> HostsCollection
@@ -100,7 +100,7 @@ class InsightsConfig(Config):
 
         self._region = "us" if region is None else region
 
-        super(InsightsConfig, self).__init__(app_id, api_key)
+        super().__init__(app_id, api_key)
 
     def build_hosts(self):
         # type: () -> HostsCollection
@@ -116,7 +116,7 @@ class RecommendationConfig(Config):
 
         self._region = "us" if region is None else region
 
-        super(RecommendationConfig, self).__init__(app_id, api_key)
+        super().__init__(app_id, api_key)
 
     def build_hosts(self):
         # type: () -> HostsCollection
@@ -132,7 +132,7 @@ class PersonalizationConfig(Config):
 
         self._region = "us" if region is None else region
 
-        super(PersonalizationConfig, self).__init__(app_id, api_key)
+        super().__init__(app_id, api_key)
 
     def build_hosts(self):
         # type: () -> HostsCollection

--- a/algoliasearch/helpers.py
+++ b/algoliasearch/helpers.py
@@ -7,10 +7,7 @@ from typing import Optional, Iterable, List, Union, Iterator, Dict, Any
 
 from algoliasearch.exceptions import MissingObjectIdException
 
-if sys.version_info >= (3, 0):
-    from urllib.parse import quote
-else:
-    from urllib import quote  # pragma: no cover
+from urllib.parse import quote
 
 
 def endpoint(path, *args):
@@ -31,10 +28,8 @@ def get_items(dictionary=None):
 
     if dictionary is None:
         items = []  # type: Iterable
-    elif sys.version_info >= (3, 0):
-        items = dictionary.items()
     else:
-        items = dictionary.iteritems()  # pragma: no cover
+        items = dictionary.items()
 
     return items
 
@@ -45,7 +40,7 @@ def assert_object_id(objects):
     for obj in objects:
         if "objectID" not in obj:
             raise MissingObjectIdException(
-                "Missing `objectID` in: {}".format(json.dumps(obj)), obj
+                f"Missing `objectID` in: {json.dumps(obj)}", obj
             )
 
 
@@ -58,15 +53,14 @@ def build_raw_response_batch(action, objects):
 def is_async_available():
     # type: () -> bool
 
-    if sys.version_info >= (3, 0):
-        try:
-            import asyncio
-            import aiohttp
-            import async_timeout
+    try:
+        import asyncio
+        import aiohttp
+        import async_timeout
 
-            return True
-        except ImportError:
-            pass
+        return True
+    except ImportError:
+        pass
 
     return False
 

--- a/algoliasearch/helpers_async.py
+++ b/algoliasearch/helpers_async.py
@@ -18,9 +18,9 @@ def _create_async_methods_in(async_client, sync_client):
     # Finally, for each method we create a {method}_async version of it
     for method in methods:
         if method not in async_client_methods and not method.startswith("_"):
-            if "{}_async".format(method) not in async_client_methods:
+            if f"{method}_async" not in async_client_methods:
                 async_client.__setattr__(
-                    "{}_async".format(method), _gen_async(sync_client, method)
+                    f"{method}_async", _gen_async(sync_client, method)
                 )
 
 

--- a/algoliasearch/http/hosts.py
+++ b/algoliasearch/http/hosts.py
@@ -3,7 +3,7 @@ from random import shuffle
 from typing import List, Optional, cast
 
 
-class Host(object):
+class Host:
     TTL = 300.0
 
     def __init__(self, url, priority=0, accept=None):
@@ -25,7 +25,7 @@ class Host(object):
         self.up = True
 
 
-class HostsCollection(object):
+class HostsCollection:
     def __init__(self, hosts):
         # type: (List[Host]) -> None
 
@@ -49,6 +49,6 @@ class HostsCollection(object):
         return [host for host in self._hosts if host.accept & CallType.WRITE]
 
 
-class CallType(object):
+class CallType:
     READ = 1
     WRITE = 2

--- a/algoliasearch/http/request_options.py
+++ b/algoliasearch/http/request_options.py
@@ -6,7 +6,7 @@ from algoliasearch.configs import Config
 from algoliasearch.helpers import get_items
 
 
-class RequestOptions(object):
+class RequestOptions:
     def __init__(self, headers, query_parameters, timeouts, data):
         # type: (Dict[str, str], Dict[str, Any], Dict[str, int], Dict[str, Any]) -> None  # noqa: E501
 
@@ -50,7 +50,7 @@ class RequestOptions(object):
         return request_options
 
 
-class Params(object):
+class Params:
     HEADERS = (
         "Content-type",
         "User-Agent",

--- a/algoliasearch/http/requester.py
+++ b/algoliasearch/http/requester.py
@@ -9,7 +9,7 @@ from urllib3.util import Retry
 from algoliasearch.http.transporter import Response, Request
 
 
-class Requester(object):
+class Requester:
     def __init__(self):
         # type: () -> None
 

--- a/algoliasearch/http/serializer.py
+++ b/algoliasearch/http/serializer.py
@@ -9,13 +9,10 @@ from typing import Union, Any, Dict
 from algoliasearch.helpers import get_items
 
 # Python 3
-if sys.version_info >= (3, 0):
-    from urllib.parse import urlencode
-else:
-    from urllib import urlencode  # pragma: no cover
+from urllib.parse import urlencode
 
 
-class QueryParametersSerializer(object):
+class QueryParametersSerializer:
     @staticmethod
     def serialize(query_parameters):
         # type: (Dict[str, Any]) -> str
@@ -31,7 +28,7 @@ class QueryParametersSerializer(object):
         return urlencode(sorted(get_items(query_parameters), key=lambda val: val[0]))
 
 
-class SettingsDeserializer(object):
+class SettingsDeserializer:
     @staticmethod
     def deserialize(data):
         # type: (Dict[str, Any]) -> dict
@@ -49,7 +46,7 @@ class SettingsDeserializer(object):
         return data
 
 
-class DataSerializer(object):
+class DataSerializer:
     @staticmethod
     def serialize(data):
         # type: (Union[Dict[str, Any], list]) -> str

--- a/algoliasearch/http/transporter.py
+++ b/algoliasearch/http/transporter.py
@@ -14,7 +14,7 @@ except ImportError:  # Already imported.
     pass
 
 
-class Transporter(object):
+class Transporter:
     def __init__(self, requester, config):
         # type: (Requester, Config) -> None
 
@@ -76,7 +76,7 @@ class Transporter(object):
 
         for host in self._retry_strategy.valid_hosts(hosts):
 
-            request.url = "https://{}/{}".format(host.url, relative_url)
+            request.url = f"https://{host.url}/{relative_url}"
 
             response = self._requester.send(request)
 
@@ -99,7 +99,7 @@ class Transporter(object):
         self._requester.close()
 
 
-class Request(object):
+class Request:
     def __init__(
         self, verb, headers, data, connect_timeout, timeout, proxies={}
     ):  # noqa: E501
@@ -134,7 +134,7 @@ class Request(object):
         return self.__dict__ == other.__dict__
 
 
-class Response(object):
+class Response:
     def __init__(
         self,
         status_code=None,
@@ -152,7 +152,7 @@ class Response(object):
         self.is_network_error = is_network_error
 
 
-class RetryStrategy(object):
+class RetryStrategy:
     def valid_hosts(self, hosts):
         # type: (list) -> list
 
@@ -204,7 +204,7 @@ class RetryStrategy(object):
         )
 
 
-class RetryOutcome(object):
+class RetryOutcome:
     SUCCESS = "SUCCESS"
     RETRY = "RETRY"
     FAIL = "FAIL"

--- a/algoliasearch/http/transporter_async.py
+++ b/algoliasearch/http/transporter_async.py
@@ -19,7 +19,7 @@ class TransporterAsync(Transporter):
 
         for host in self._retry_strategy.valid_hosts(hosts):
 
-            request.url = "https://{}/{}".format(host.url, relative_url)
+            request.url = f"https://{host.url}/{relative_url}"
 
             response = yield from self._requester.send(request)  # type: ignore
 

--- a/algoliasearch/http/verb.py
+++ b/algoliasearch/http/verb.py
@@ -1,4 +1,4 @@
-class Verb(object):
+class Verb:
     GET = "GET"
     POST = "POST"
     PUT = "PUT"

--- a/algoliasearch/insights_client.py
+++ b/algoliasearch/insights_client.py
@@ -8,7 +8,7 @@ from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.verb import Verb
 
 
-class InsightsClient(object):
+class InsightsClient:
     def __init__(self, transporter, search_config):
         # type: (Transporter, InsightsConfig) -> None
 

--- a/algoliasearch/insights_client_async.py
+++ b/algoliasearch/insights_client_async.py
@@ -15,7 +15,7 @@ class InsightsClientAsync(InsightsClient):
 
         self._transporter_async = transporter
 
-        super(InsightsClientAsync, self).__init__(
+        super().__init__(
             insights_client._transporter, insights_config
         )
 
@@ -52,7 +52,7 @@ class UserInsightsClientAsync(UserInsightsClient):
     def __init__(self, insights_client, user_token):
         # type: (InsightsClient, str) -> None
 
-        super(UserInsightsClientAsync, self).__init__(insights_client, user_token)
+        super().__init__(insights_client, user_token)
 
         client = UserInsightsClient(insights_client, user_token)
 

--- a/algoliasearch/iterators.py
+++ b/algoliasearch/iterators.py
@@ -8,7 +8,7 @@ from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.verb import Verb
 
 
-class Iterator(object):
+class Iterator:
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, transporter, index_name, request_options=None):
@@ -41,7 +41,7 @@ class PaginatorIterator(Iterator):
     def __init__(self, transporter, index_name, request_options=None):
         # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
-        super(PaginatorIterator, self).__init__(
+        super().__init__(
             transporter, index_name, request_options
         )
         self._data = {

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -16,7 +16,7 @@ class PaginatorIteratorAsync(Iterator):
     def __init__(self, transporter, index_name, request_options=None):
         # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
-        super(PaginatorIteratorAsync, self).__init__(
+        super().__init__(
             transporter, index_name, request_options
         )
         self._data = {

--- a/algoliasearch/personalization_client.py
+++ b/algoliasearch/personalization_client.py
@@ -8,7 +8,7 @@ from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.verb import Verb
 
 
-class PersonalizationClient(object):
+class PersonalizationClient:
     def __init__(self, transporter, config):
         # type: (Transporter, PersonalizationConfig) -> None
 

--- a/algoliasearch/personalization_client_async.py
+++ b/algoliasearch/personalization_client_async.py
@@ -14,7 +14,7 @@ class PersonalizationClientAsync(PersonalizationClient):
 
         self._transporter_async = transporter
 
-        super(PersonalizationClientAsync, self).__init__(
+        super().__init__(
             personalization_client._transporter, search_config
         )
 

--- a/algoliasearch/recommend_client.py
+++ b/algoliasearch/recommend_client.py
@@ -8,7 +8,7 @@ from algoliasearch.http.requester import Requester
 from algoliasearch.http.transporter import Transporter
 
 
-class RecommendClient(object):
+class RecommendClient:
     @property
     def app_id(self):
         # type: () -> str

--- a/algoliasearch/recommend_client_async.py
+++ b/algoliasearch/recommend_client_async.py
@@ -16,7 +16,7 @@ class RecommendClientAsync(RecommendClient):
         self._recommend_client = recommend_client
         self._transporter_async = transporter
 
-        super(RecommendClientAsync, self).__init__(
+        super().__init__(
             recommend_client._transporter, search_config
         )
 

--- a/algoliasearch/recommendation_client.py
+++ b/algoliasearch/recommendation_client.py
@@ -9,7 +9,7 @@ from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.verb import Verb
 
 
-class RecommendationClient(object):
+class RecommendationClient:
     def __init__(self, transporter, config):
         # type: (Transporter, RecommendationConfig) -> None
 

--- a/algoliasearch/recommendation_client_async.py
+++ b/algoliasearch/recommendation_client_async.py
@@ -14,7 +14,7 @@ class RecommendationClientAsync(RecommendationClient):
 
         self._transporter_async = transporter
 
-        super(RecommendationClientAsync, self).__init__(
+        super().__init__(
             recommendation_client._transporter, search_config
         )
 

--- a/algoliasearch/responses.py
+++ b/algoliasearch/responses.py
@@ -21,7 +21,7 @@ except ImportError:  # Already imported.
     pass
 
 
-class Response(object):
+class Response:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod

--- a/algoliasearch/search_client.py
+++ b/algoliasearch/search_client.py
@@ -28,7 +28,7 @@ from algoliasearch.http.requester import Requester
 from algoliasearch.http.hosts import CallType
 
 
-class SearchClient(object):
+class SearchClient:
     @property
     def app_id(self):
         # type: () -> str
@@ -278,7 +278,7 @@ class SearchClient(object):
         ).hexdigest()
 
         base64encoded = base64.b64encode(
-            ("{}{}".format(secured_key, query_parameters)).encode("utf-8")
+            (f"{secured_key}{query_parameters}").encode("utf-8")
         )
 
         return str(base64encoded.decode("utf-8"))

--- a/algoliasearch/search_client_async.py
+++ b/algoliasearch/search_client_async.py
@@ -17,7 +17,7 @@ class SearchClientAsync(SearchClient):
         self._search_client = search_client
         self._transporter_async = transporter
 
-        super(SearchClientAsync, self).__init__(
+        super().__init__(
             search_client._transporter, search_config
         )
 

--- a/algoliasearch/search_index.py
+++ b/algoliasearch/search_index.py
@@ -21,7 +21,7 @@ from algoliasearch.iterators import ObjectIterator, SynonymIterator, RuleIterato
 from algoliasearch.responses import Response, IndexingResponse, MultipleResponse
 
 
-class SearchIndex(object):
+class SearchIndex:
     @property
     def app_id(self):
         return self._config.app_id
@@ -577,7 +577,7 @@ class SearchIndex(object):
 
         letters = string.ascii_letters
         random_string = "".join(random.choice(letters) for i in range(10))
-        tmp_index_name = "{}_tmp_{}".format(self._name, random_string)
+        tmp_index_name = f"{self._name}_tmp_{random_string}"
 
         return tmp_index_name
 

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -29,7 +29,7 @@ class SearchIndexAsync(SearchIndex):
         self._search_index = search_index
         self._transporter_async = transporter
 
-        super(SearchIndexAsync, self).__init__(search_index._transporter, config, name)
+        super().__init__(search_index._transporter, config, name)
 
         search_index = SearchIndex(transporter, config, name)
         search_index.__setattr__("_sync", self._sync)

--- a/algoliasearch/user_agent.py
+++ b/algoliasearch/user_agent.py
@@ -2,7 +2,7 @@ from algoliasearch.version import VERSION
 from platform import python_version
 
 
-class UserAgent(object):
+class UserAgent:
     value = "Algolia for Python ({}); Python ({})".format(
         VERSION, str(python_version())
     )
@@ -17,4 +17,4 @@ class UserAgent(object):
     def add(segment, version):
         # type: (str, str) -> None
 
-        UserAgent.value += "; {} ({})".format(segment, version)
+        UserAgent.value += f"; {segment} ({version})"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,10 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Internet
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: Indexing/Search
@@ -36,7 +35,7 @@ packages = find:
 install_requires =
     requests>=2.21,<3.0
     typing>=3.6,<4.0;python_version<"3.5"
-python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, !=3.3.*
+python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,7 @@ include_package_data = True
 packages = find:
 install_requires =
     requests>=2.21,<3.0
-    typing>=3.6,<4.0;python_version<"3.5"
-python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*
+python_requires = >= 3.7
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,38,39}-sync
-    py{34,35,36,37,38,39}-async
+    py{27,37,38,39,310}-sync
+    py{37,38,39,310}-async
     format
     types
 install_command = python -m pip install --user {opts} {packages}
@@ -26,9 +26,9 @@ deps =
     faker {[versions]faker}
     mock {[versions]mock}
     typing {[versions]typing}
-    py{34,35,36,37,38,39}-async: asyncio {[versions]asyncio}
-    py{34,35,36,37,38,39}-async: aiohttp {[versions]aiohttp}
-    py{34,35,36,37,38,39}-async: async_timeout {[versions]async_timeout}
+    py{37,38,39,310}-async: asyncio {[versions]asyncio}
+    py{37,38,39,310}-async: aiohttp {[versions]aiohttp}
+    py{37,38,39,310}-async: async_timeout {[versions]async_timeout}
 passenv =
     ALGOLIA_APPLICATION_ID_1
     ALGOLIA_ADMIN_KEY_1
@@ -40,8 +40,7 @@ passenv =
 commands =
     py27-sync: python -m unittest discover -v
     py27-async: python -c 'print "No asynchronous tests for Python 2.7, skipping."'
-    py{34,35,36}-{sync,async}: python -m unittest discover -v
-    py{37,38,39}-{sync,async}: python -m unittest discover -v -k {posargs:*}
+    py{37,38,39,310}-{sync,async}: python -m unittest discover -v -k {posargs:*}
 
 [testenv:types]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,37,38,39,310}-sync
+    py{37,38,39,310}-sync
     py{37,38,39,310}-async
     format
     types
@@ -38,8 +38,6 @@ passenv =
     ALGOLIA_APPLICATION_ID_MCM
     ALGOLIA_ADMIN_KEY_MCM
 commands =
-    py27-sync: python -m unittest discover -v
-    py27-async: python -c 'print "No asynchronous tests for Python 2.7, skipping."'
     py{37,38,39,310}-{sync,async}: python -m unittest discover -v -k {posargs:*}
 
 [testenv:types]


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | yes
| Need Doc update   | yes


## Describe your change

I've added Python 3.10 to your tox configuration to check that the
library is compatible with this version. It's working well on my
machine.

I've also removed the stale version of Python 3 which are actually
deprecated[^1].

| Release | Released    | Security Support                             |
|---------|-------------|----------------------------------------------|
| 3.6     | 22 Dec 2016 | Ended 9 months ago (23 Dec 2021)             |
| 3.5     | 12 Sep 2015 | Ended 2 years ago (13 Sep 2020)              |
| 3.4     | 15 Mar 2014 | Ended 3 years and 6 months ago (18 Mar 2019) |
| 3.3     | 29 Sep 2012 | Ended 5 years ago (29 Sep 2017)              |

In a second commit, I've removed support for Python 2.7 and upgrade the codebase to Python 3.6[^2]


### 📝 Note for reviewers

* Better review commit by commit.
* I can totally drop the second commit that removes the support of Python 2.7 so let me know.

[^1]: Table that describe python end of life: https://endoflife.date/python
[^2]: I've used python-upgrade for this: https://github.com/asottile/pyupgrade#readme
