### PR TITLE
Fix: preventing KeyError("_highlightResult")

### DIFF
--- a/algoliasearch/iterators.py
+++ b/algoliasearch/iterators.py
@@ -35,6 +35,8 @@ class Iterator(object):
 
 
 class PaginatorIterator(Iterator):
+    nbHits = 0
+
     def __init__(self, transporter, index_name, request_options=None):
         # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
@@ -57,7 +59,7 @@ class PaginatorIterator(Iterator):
 
                 return hit
 
-            if self._raw_response["nbHits"] < self._data["hitsPerPage"]:
+            if self.nbHits < self._data["hitsPerPage"]:
                 self._raw_response = {}
                 self._data = {
                     "hitsPerPage": 1000,
@@ -68,6 +70,7 @@ class PaginatorIterator(Iterator):
         self._raw_response = self._transporter.read(
             Verb.POST, self.get_endpoint(), self._data, self._request_options
         )
+        self.nbHits = len(self._raw_response["hits"])
 
         self._data["page"] += 1
 

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -10,6 +10,8 @@ from algoliasearch.iterators import Iterator
 
 
 class PaginatorIteratorAsync(Iterator):
+    nbHits = 0
+
     def __init__(self, transporter, index_name, request_options=None):
         # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
@@ -38,7 +40,7 @@ class PaginatorIteratorAsync(Iterator):
 
                 return hit
 
-            if self._raw_response["nbHits"] < self._data["hitsPerPage"]:
+            if self.nbHits < self._data["hitsPerPage"]:
                 self._raw_response = {}
                 self._data = {
                     "hitsPerPage": 1000,
@@ -49,6 +51,7 @@ class PaginatorIteratorAsync(Iterator):
         self._raw_response = yield from self._transporter.read(
             Verb.POST, self.get_endpoint(), self._data, self._request_options
         )
+        self.nbHits = len(self._raw_response["hits"])
 
         self._data["page"] += 1
 

--- a/tests/features/test_search_index.py
+++ b/tests/features/test_search_index.py
@@ -14,6 +14,7 @@ from tests.helpers.factory import Factory as F
 from tests.helpers.misc import Unicode, rule_without_metadata
 from unittest.mock import MagicMock
 
+
 class TestSearchIndex(unittest.TestCase):
     def setUp(self):
         self.client = F.search_client()
@@ -456,7 +457,6 @@ class TestSearchIndex(unittest.TestCase):
         self.assertEqual(self.index.search_synonyms("")["nbHits"], 0)
 
     def test_browse_rules(self):
-
         def side_effect(req, **kwargs):
             hits = [{"objectID": i, "_highlightResult": None} for i in range(0, 1000)]
             page = json.loads(req.body)["page"]
@@ -467,12 +467,14 @@ class TestSearchIndex(unittest.TestCase):
             response = Response()
             response.status_code = 200
             response._content = str.encode(
-                json.dumps({
-                    "hits": hits,
-                    "nbHits": 3800,
-                    "page": page,
-                    "nbPages": 3,
-                })
+                json.dumps(
+                    {
+                        "hits": hits,
+                        "nbHits": 3800,
+                        "page": page,
+                        "nbPages": 3,
+                    }
+                )
             )
 
             return response

--- a/tox.ini
+++ b/tox.ini
@@ -74,4 +74,4 @@ passenv =
 commands =
     python setup.py sdist bdist_wheel
     twine check dist/*
-    twine upload --username $PYPI_USER --password $PYPI_PASSWORD dist/*
+    twine upload -u {env:PYPI_USER} -p {env:PYPI_PASSWORD} --repository-url https://upload.pypi.org/legacy/ dist/*


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #544 
| Need Doc update   | no


## Describe your change

Checking if the _highlightResult key is present before calling the pop method in the iterators.py file on line 58

```
if ("_highlightResult" in hit):
                    hit.pop("_highlightResult")
```


## What problem is this fixing?

Prevent returning error - KeyError: ‘_highlightResult’ while using browse_rules() method
