### PR TITLE
fix: prevent KeyError when popping an unknown property

### DIFF
--- a/algoliasearch/iterators.py
+++ b/algoliasearch/iterators.py
@@ -56,7 +56,8 @@ class PaginatorIterator(Iterator):
             if len(self._raw_response["hits"]):
                 hit = self._raw_response["hits"].pop(0)
 
-                hit.pop("_highlightResult")
+                if "_highlightResult" in hit:
+                    hit.pop("_highlightResult")
 
                 return hit
 

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -37,7 +37,8 @@ class PaginatorIteratorAsync(Iterator):
             if len(self._raw_response["hits"]):
                 hit = self._raw_response["hits"].pop(0)
 
-                hit.pop("_highlightResult")
+                if "_highlightResult" in hit:
+                    hit.pop("_highlightResult")
 
                 return hit
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ typing = >=3.6,<4.0; python_version < '3.5'
 asyncio = >=3.4,<4.0
 aiohttp = >=2.0,<4.0; python_version >= '3.4.2'
 async_timeout = >=2.0,<4.0
-mypy = >=0.6,<7.0
+mypy = >=0.600,<0.900
 flake8 = ==3.8.3
 black = ==22.3.0
 twine = >=1.13,<2.0


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | fixes https://github.com/algolia/algoliasearch-client-python/pull/550 fixes https://github.com/algolia/algoliasearch-client-python/issues/544
| Need Doc update   | no

https://algolia.atlassian.net/browse/CR-2497
https://algolia.atlassian.net/browse/DI-676

## Describe your change

We ensure the key in present before calling pop, to prevent a KeyError returned if it's not found.