### PR TITLE
feat: add support for Python 3.9, 3.10 and 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/python:<< parameters.docker_version >>
+      - image: cimg/python:<< parameters.docker_version >>
     description: Run tests for Python << parameters.tox_version >>
     parameters:
       docker_version:
@@ -21,7 +21,7 @@ jobs:
 
   format:
     docker:
-      - image: circleci/python:3.8.2
+      - image: cimg/python:3.8.2
     description: Run formatting and linting checks
     steps:
       - checkout
@@ -34,7 +34,7 @@ jobs:
 
   types:
     docker:
-      - image: circleci/python:3.8.2
+      - image: cimg/python:3.8.2
     description: Run optional type checking with MyPy
     steps:
       - checkout
@@ -47,7 +47,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/python:3.8.2
+      - image: cimg/python:3.8.2
     description: Perform a new release of the Python client
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/python:<< parameters.docker_version >>
+      - image: << parameters.docker_version >>
     description: Run tests for Python << parameters.tox_version >>
     parameters:
       docker_version:
@@ -67,56 +67,56 @@ workflows:
     jobs:
       - test:
           name: 'test_34'
-          docker_version: '3.4'
+          docker_version: 'circleci/python:3.4'
           tox_version: '34'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_35'
-          docker_version: '3.5'
+          docker_version: 'cimg/python:3.5'
           tox_version: '35'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_36'
-          docker_version: '3.6'
+          docker_version: 'cimg/python:3.6'
           tox_version: '36'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_37'
-          docker_version: '3.7'
+          docker_version: 'cimg/python:3.7'
           tox_version: '37'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_38'
-          docker_version: '3.8'
+          docker_version: 'cimg/python:3.8'
           tox_version: '38'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_39'
-          docker_version: '3.9'
+          docker_version: 'cimg/python:3.9'
           tox_version: '39'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_310'
-          docker_version: '3.10'
+          docker_version: 'cimg/python:3.10'
           tox_version: '310'
           filters:
             tags:
               only: /.*/
       - test:
           name: 'test_311'
-          docker_version: '3.11.1'
+          docker_version: 'cimg/python:3.11.1'
           tox_version: '311'
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,26 @@ jobs:
         type: string
     steps:
       - checkout
-      - run:
-          command: pip install --upgrade pip
-      - run:
-          command: pip install tox mock
+      - when:
+          condition:
+            matches:
+              pattern: ".*circleci.*"
+              value: << parameters.docker_version >>
+          steps:
+            - run:
+                command: sudo pip install --upgrade pip
+            - run:
+                command: sudo pip install tox mock
+      - when:
+          condition:
+            matches:
+              pattern: ".*cimg.*"
+              value: << parameters.docker_version >>
+          steps:
+            - run:
+                command: pip install --upgrade pip
+            - run:
+                command: pip install tox mock
       - run:
           command: tox -e py<< parameters.tox_version >>-sync,py<< parameters.tox_version >>-async
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,6 @@ workflows:
   build:
     jobs:
       - test:
-          name: 'test_27'
-          docker_version: '2.7'
-          tox_version: '27'
-          filters:
-            tags:
-              only: /.*/
-      - test:
           name: 'test_34'
           docker_version: '3.4'
           tox_version: '34'
@@ -119,7 +112,6 @@ workflows:
               only: /.*/
       - release:
           requires:
-            - test_27
             - test_34
             - test_35
             - test_36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,27 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test:
+          name: 'test_39'
+          docker_version: '3.9'
+          tox_version: '39'
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          name: 'test_310'
+          docker_version: '3.10'
+          tox_version: '310'
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          name: 'test_311'
+          docker_version: '3.11'
+          tox_version: '311'
+          filters:
+            tags:
+              only: /.*/
       - format:
           name: 'format'
           filters:
@@ -117,6 +138,9 @@ workflows:
             - test_36
             - test_37
             - test_38
+            - test_39
+            - test_310
+            - test_311
             - format
             - types
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
               only: /.*/
       - test:
           name: 'test_311'
-          docker_version: '3.11'
+          docker_version: '3.11.1'
           tox_version: '311'
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - checkout
       - run:
-          command: sudo pip install --upgrade pip
+          command: pip install --upgrade pip
       - run:
-          command: sudo pip install tox mock
+          command: pip install tox mock
       - run:
           command: tox -e py<< parameters.tox_version >>-sync,py<< parameters.tox_version >>-async
 
@@ -26,9 +26,9 @@ jobs:
     steps:
       - checkout
       - run:
-          command: sudo pip install --upgrade pip
+          command: pip install --upgrade pip
       - run:
-          command: sudo pip install tox
+          command: pip install tox
       - run:
           command: tox -e format
 
@@ -39,9 +39,9 @@ jobs:
     steps:
       - checkout
       - run:
-          command: sudo pip install --upgrade pip
+          command: pip install --upgrade pip
       - run:
-          command: sudo pip install tox
+          command: pip install tox
       - run:
           command: tox -e types
 
@@ -52,9 +52,9 @@ jobs:
     steps:
       - checkout
       - run:
-          command: sudo pip install --upgrade pip
+          command: pip install --upgrade pip
       - run:
-          command: sudo pip install tox
+          command: pip install tox
       - run:
           command: |
             if [[ -z "$PYPI_USER" ]];     then echo '$PYPI_USER is not set';     exit 1; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-python/compare/v2.6.3...master)
 
+## [v3.0.0](https://github.com/algolia/algoliasearch-client-python/compare/v2.6.2...v3.0.0)
+
+### Changed
+
+- Major version: Python 2.7 is no longer supported
+
+### Fixed
+ - Unable to initialize SearchClient on Python 3.11 ([#549](https://github.com/algolia/algoliasearch-client-python/issues/549))
+
 ## [v2.6.3](https://github.com/algolia/algoliasearch-client-python/compare/v2.6.2...v2.6.3)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Major version: Python 2.7 is no longer supported
+- Major version: Python 2.7 is no longer supported, adds support until Python 3.11
 
 ### Fixed
  - Unable to initialize SearchClient on Python 3.11 ([#549](https://github.com/algolia/algoliasearch-client-python/issues/549))

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## ✨ Features
 
 - Thin & minimal low-level HTTP client to interact with Algolia's API
-- Supports Python: `2.7`, `3.4`, `3.5`, `3.6`, `3.7`, and `3.8`
+- Supports Python: `3.4`, `3.5`, `3.6`, `3.7`, and `3.8`
 - Contains blazing-fast asynchronous methods built on top of the [Asyncio](https://docs.python.org/3/library/asyncio.html)
 
 ## 💡 Getting Started

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## ✨ Features
 
 - Thin & minimal low-level HTTP client to interact with Algolia's API
-- Supports Python: `3.4`, `3.5`, `3.6`, `3.7`, and `3.8`
+- Supports Python from `3.4` to `3.11`
 - Contains blazing-fast asynchronous methods built on top of the [Asyncio](https://docs.python.org/3/library/asyncio.html)
 
 ## 💡 Getting Started

--- a/algoliasearch/analytics_client_async.py
+++ b/algoliasearch/analytics_client_async.py
@@ -1,6 +1,5 @@
 import types
 
-import asyncio
 from typing import Optional, Type
 
 from algoliasearch.analytics_client import AnalyticsClient
@@ -23,22 +22,19 @@ class AnalyticsClientAsync(AnalyticsClient):
 
         _create_async_methods_in(self, client)
 
-    @asyncio.coroutine
     def __aenter__(self):
         # type: () -> AnalyticsClientAsync # type: ignore
 
         return self  # type: ignore
 
-    @asyncio.coroutine
     def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        yield from self.close_async()  # type: ignore
+        return self.close_async()  # type: ignore
 
-    @asyncio.coroutine
     def close_async(self):  # type: ignore
         # type: () -> None
 
         super().close()
 
-        yield from self._transporter_async.close()  # type: ignore
+        return self._transporter_async.close()  # type: ignore

--- a/algoliasearch/analytics_client_async.py
+++ b/algoliasearch/analytics_client_async.py
@@ -22,19 +22,23 @@ class AnalyticsClientAsync(AnalyticsClient):
 
         _create_async_methods_in(self, client)
 
-    def __aenter__(self):
-        # type: () -> AnalyticsClientAsync # type: ignore
+    async def __aenter__(self):
+        # type: () -> AnalyticsClientAsync
 
-        return self  # type: ignore
+        return self
 
-    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+    async def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        return self.close_async()  # type: ignore
+        self.close_async()
 
-    def close_async(self):  # type: ignore
+        return
+
+    async def close_async(self):
         # type: () -> None
 
         super().close()
 
-        return self._transporter_async.close()  # type: ignore
+        self._transporter_async.close()
+
+        return

--- a/algoliasearch/helpers_async.py
+++ b/algoliasearch/helpers_async.py
@@ -1,4 +1,3 @@
-import asyncio
 import types
 
 from typing import Callable
@@ -29,7 +28,7 @@ def _gen_async(client, method):
 
     m = getattr(client, method)
 
-    def closure(*args, **kwargs):
+    async def closure(*args, **kwargs):
         result = m(*args, **kwargs)
 
         # We make sure we resolve the promise from the raw_responses
@@ -38,16 +37,16 @@ def _gen_async(client, method):
                 i,
                 raw_response,
             ) in enumerate(result.raw_responses):
-                result.raw_responses[i] = yield from raw_response
+                result.raw_responses[i] = await raw_response
 
         # We make sure we resolve the promise from the raw_response
         if hasattr(result, "raw_response"):
-            result.raw_response = yield from result.raw_response
+            result.raw_response = await result.raw_response
 
         # We make sure we resolve the promise
         if isinstance(result, types.GeneratorType):
-            result = yield from result
+            result = await result
 
         return result
 
-    return asyncio.coroutine(closure)
+    return closure

--- a/algoliasearch/http/requester_async.py
+++ b/algoliasearch/http/requester_async.py
@@ -13,8 +13,7 @@ class RequesterAsync(Requester):
 
         self._session = None
 
-    @asyncio.coroutine  # type: ignore
-    def send(self, request):  # type: ignore
+    async def send(self, request):  # type: ignore
         # type: (Request) -> Response
 
         if self._session is None:
@@ -29,7 +28,7 @@ class RequesterAsync(Requester):
 
         try:
             with async_timeout.timeout(request.timeout):
-                response = yield from (
+                response = await (
                     self._session.request(  # type: ignore
                         method=request.verb,
                         url=request.url,
@@ -39,7 +38,7 @@ class RequesterAsync(Requester):
                     )
                 )
 
-                json = yield from response.json()
+                json = await response.json()
 
         except asyncio.TimeoutError as e:
 
@@ -47,12 +46,11 @@ class RequesterAsync(Requester):
 
         return Response(response.status, json, str(response.reason))
 
-    @asyncio.coroutine
-    def close(self):  # type: ignore
+    async def close(self):  # type: ignore
         # type: () -> None
 
         if self._session is not None:
             session = self._session
             self._session = None
 
-            yield from session.close()  # type: ignore
+            await session.close()  # type: ignore

--- a/algoliasearch/http/transporter_async.py
+++ b/algoliasearch/http/transporter_async.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from algoliasearch.configs import Config
 from algoliasearch.exceptions import RequestException, AlgoliaUnreachableHostException
 from algoliasearch.http.hosts import HostsCollection
@@ -13,15 +11,14 @@ from algoliasearch.http.transporter import (
 
 
 class TransporterAsync(Transporter):
-    @asyncio.coroutine
-    def retry(self, hosts, request, relative_url):  # type: ignore
+    async def retry(self, hosts, request, relative_url):  # type: ignore
         # type: (list, Request, str) -> dict
 
         for host in self._retry_strategy.valid_hosts(hosts):
 
             request.url = "https://{}/{}".format(host.url, relative_url)
 
-            response = yield from self._requester.send(request)  # type: ignore
+            response = await self._requester.send(request)  # type: ignore
 
             decision = self._retry_strategy.decide(host, response)
 
@@ -37,8 +34,7 @@ class TransporterAsync(Transporter):
 
         raise AlgoliaUnreachableHostException("Unreachable hosts")
 
-    @asyncio.coroutine
-    def close(self):  # type: ignore
+    async def close(self):  # type: ignore
         # type: () -> None
 
-        yield from self._requester.close()  # type: ignore
+        await self._requester.close()  # type: ignore

--- a/algoliasearch/insights_client_async.py
+++ b/algoliasearch/insights_client_async.py
@@ -27,25 +27,22 @@ class InsightsClientAsync(InsightsClient):
 
         return UserInsightsClientAsync(self, user_token)
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async def __aenter__(self):
         # type: () -> InsightsClientAsync # type: ignore
 
         return self  # type: ignore
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+    async def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        yield from self.close_async()  # type: ignore
+        await self.close_async()  # type: ignore
 
-    @asyncio.coroutine
-    def close_async(self):  # type: ignore
+    async def close_async(self):  # type: ignore
         # type: () -> None
 
         super().close()
 
-        yield from self._transporter_async.close()  # type: ignore
+        await self._transporter_async.close()  # type: ignore
 
 
 class UserInsightsClientAsync(UserInsightsClient):

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -49,7 +49,7 @@ class PaginatorIteratorAsync(Iterator):
                 }
                 raise StopAsyncIteration
 
-        self._raw_response = await self._transporter.read(
+        self._raw_response = self._transporter.read(
             Verb.POST, self.get_endpoint(), self._data, self._request_options
         )
         self.nbHits = len(self._raw_response["hits"])
@@ -78,10 +78,7 @@ class ObjectIteratorAsync(Iterator):
 
         if self._raw_response:
             if len(self._raw_response["hits"]):
-                result = self._raw_response["hits"].pop(0)
-
-                yield result
-                return
+                return self._raw_response["hits"].pop(0)
 
             if "cursor" not in self._raw_response:
                 self._raw_response = {}
@@ -89,15 +86,14 @@ class ObjectIteratorAsync(Iterator):
             else:
                 data["cursor"] = self._raw_response["cursor"]
 
-        self._raw_response = await self._transporter.read(
+        self._raw_response = self._transporter.read(
             Verb.POST,
             endpoint("1/indexes/{}/browse", self._index_name),
             data,
             self._request_options,
         )
 
-        yield self.__anext__()
-        return
+        return await self.__anext__()
 
 
 class SynonymIteratorAsync(PaginatorIteratorAsync):

--- a/algoliasearch/iterators_async.py
+++ b/algoliasearch/iterators_async.py
@@ -1,11 +1,11 @@
 import abc
 import asyncio
 
-from typing import Optional, Union
+from typing import Optional, Union, Dict, Any
 from algoliasearch.helpers import endpoint
 
 from algoliasearch.http.request_options import RequestOptions
-from algoliasearch.http.transporter import Transporter
+from algoliasearch.http.transporter_async import TransporterAsync
 from algoliasearch.http.verb import Verb
 from algoliasearch.iterators import Iterator
 
@@ -14,7 +14,7 @@ class PaginatorIteratorAsync(Iterator):
     nbHits = 0
 
     def __init__(self, transporter, index_name, request_options=None):
-        # type: (Transporter, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
+        # type: (TransporterAsync, str, Optional[Union[dict, RequestOptions]]) -> None  # noqa: E501
 
         super(PaginatorIteratorAsync, self).__init__(
             transporter, index_name, request_options
@@ -49,7 +49,7 @@ class PaginatorIteratorAsync(Iterator):
                 }
                 raise StopAsyncIteration
 
-        self._raw_response = self._transporter.read(
+        self._raw_response = await self._transporter.read(  # type: ignore
             Verb.POST, self.get_endpoint(), self._data, self._request_options
         )
         self.nbHits = len(self._raw_response["hits"])
@@ -86,7 +86,7 @@ class ObjectIteratorAsync(Iterator):
             else:
                 data["cursor"] = self._raw_response["cursor"]
 
-        self._raw_response = self._transporter.read(
+        self._raw_response = await self._transporter.read(  # type: ignore
             Verb.POST,
             endpoint("1/indexes/{}/browse", self._index_name),
             data,

--- a/algoliasearch/personalization_client_async.py
+++ b/algoliasearch/personalization_client_async.py
@@ -22,7 +22,7 @@ class PersonalizationClientAsync(PersonalizationClient):
 
         _create_async_methods_in(self, client)
 
-    async ef __aenter__(self):
+    async def __aenter__(self):
         # type: () -> PersonalizationClientAsync # type: ignore
 
         return self  # type: ignore

--- a/algoliasearch/personalization_client_async.py
+++ b/algoliasearch/personalization_client_async.py
@@ -22,22 +22,19 @@ class PersonalizationClientAsync(PersonalizationClient):
 
         _create_async_methods_in(self, client)
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async ef __aenter__(self):
         # type: () -> PersonalizationClientAsync # type: ignore
 
         return self  # type: ignore
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+    async def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        yield from self.close_async()  # type: ignore
+        await self.close_async()  # type: ignore
 
-    @asyncio.coroutine
-    def close_async(self):  # type: ignore
+    async def close_async(self):  # type: ignore
         # type: () -> None
 
         super().close()
 
-        yield from self._transporter_async.close()  # type: ignore
+        await self._transporter_async.close()  # type: ignore

--- a/algoliasearch/recommend_client_async.py
+++ b/algoliasearch/recommend_client_async.py
@@ -24,25 +24,22 @@ class RecommendClientAsync(RecommendClient):
         recommend_client.__setattr__("_sync", self._sync)
         _create_async_methods_in(self, recommend_client)
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async def __aenter__(self):
         # type: () -> RecommendClientAsync # type: ignore
 
         return self  # type: ignore
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+    async def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        yield from self.close_async()  # type: ignore
+        await self.close_async()  # type: ignore
 
-    @asyncio.coroutine
-    def close_async(self):  # type: ignore
+    async def close_async(self):  # type: ignore
         # type: () -> None
 
         super().close()
 
-        yield from self._transporter_async.close()  # type: ignore
+        await self._transporter_async.close()  # type: ignore
 
     def _sync(self):
         # type: () -> RecommendClient

--- a/algoliasearch/recommendation_client_async.py
+++ b/algoliasearch/recommendation_client_async.py
@@ -22,22 +22,19 @@ class RecommendationClientAsync(RecommendationClient):
 
         _create_async_methods_in(self, client)
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async def __aenter__(self):
         # type: () -> RecommendationClientAsync # type: ignore
 
         return self  # type: ignore
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+    async def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        yield from self.close_async()  # type: ignore
+        await self.close_async()  # type: ignore
 
-    @asyncio.coroutine
-    def close_async(self):  # type: ignore
+    async def close_async(self):  # type: ignore
         # type: () -> None
 
         super().close()
 
-        yield from self._transporter_async.close()  # type: ignore
+        await self._transporter_async.close()  # type: ignore

--- a/algoliasearch/search_client_async.py
+++ b/algoliasearch/search_client_async.py
@@ -33,25 +33,22 @@ class SearchClientAsync(SearchClient):
 
         return SearchIndexAsync(index, self._transporter_async, self._config, name)
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async def __aenter__(self):
         # type: () -> SearchClientAsync # type: ignore
 
         return self  # type: ignore
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc, tb):  # type: ignore
+    async def __aexit__(self, exc_type, exc, tb):  # type: ignore
         # type: (Optional[Type[BaseException]], Optional[BaseException],Optional[types.TracebackType]) -> None # noqa: E501
 
-        yield from self.close_async()  # type: ignore
+        await self.close_async()  # type: ignore
 
-    @asyncio.coroutine
-    def close_async(self):  # type: ignore
+    async def close_async(self):  # type: ignore
         # type: () -> None
 
         super().close()
 
-        yield from self._transporter_async.close()  # type: ignore
+        await self._transporter_async.close()  # type: ignore
 
     def _sync(self):
         # type: () -> SearchClient

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -51,7 +51,7 @@ class SearchIndexAsync(SearchIndex):
             factor = math.ceil(retries_count / 10)
             sleep_for = factor * self._config.wait_task_time_before_retry
 
-            asyncio.sleep(sleep_for / 1000000.0)
+            await asyncio.sleep(sleep_for / 1000000.0)
             return
 
     def browse_objects_async(self, request_options=None):

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -36,14 +36,13 @@ class SearchIndexAsync(SearchIndex):
 
         _create_async_methods_in(self, search_index)
 
-    @asyncio.coroutine
-    def wait_task_async(self, task_id, request_options=None):  # type: ignore
+    async def wait_task_async(self, task_id, request_options=None):  # type: ignore
         # type: (int, Optional[Union[dict, RequestOptions]]) -> None
 
         retries_count = 1
 
         while True:
-            task = yield from self.get_task_async(  # type: ignore
+            task = await self.get_task_async(  # type: ignore
                 task_id, request_options
             )
 
@@ -54,7 +53,7 @@ class SearchIndexAsync(SearchIndex):
             factor = math.ceil(retries_count / 10)
             sleep_for = factor * self._config.wait_task_time_before_retry
 
-            yield from asyncio.sleep(sleep_for / 1000000.0)
+            return asyncio.sleep(sleep_for / 1000000.0)
 
     def browse_objects_async(self, request_options=None):
         # type: (Optional[Union[dict, RequestOptions]]) -> ObjectIteratorAsync

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -42,9 +42,7 @@ class SearchIndexAsync(SearchIndex):
         retries_count = 1
 
         while True:
-            task = await self.get_task_async(  # type: ignore
-                task_id, request_options
-            )
+            task = await self.get_task_async(task_id, request_options)  # type: ignore
 
             if task["status"] == "published":
                 break

--- a/algoliasearch/search_index_async.py
+++ b/algoliasearch/search_index_async.py
@@ -51,7 +51,8 @@ class SearchIndexAsync(SearchIndex):
             factor = math.ceil(retries_count / 10)
             sleep_for = factor * self._config.wait_task_time_before_retry
 
-            return asyncio.sleep(sleep_for / 1000000.0)
+            asyncio.sleep(sleep_for / 1000000.0)
+            return
 
     def browse_objects_async(self, request_options=None):
         # type: (Optional[Union[dict, RequestOptions]]) -> ObjectIteratorAsync

--- a/algoliasearch/version.py
+++ b/algoliasearch/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.6.3"
+VERSION = "3.0.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ packages = find:
 install_requires =
     requests>=2.21,<3.0
     typing>=3.6,<4.0;python_version<"3.5"
-python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, !=3.3.*
+python_requires = >= 3.4
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = algoliasearch
-version = 2.6.3
+version = 3.0.0
 author = Algolia Team
 author_email = support@algolia.com
 maintainer = Algolia Team

--- a/tests/helpers/misc_async.py
+++ b/tests/helpers/misc_async.py
@@ -51,14 +51,14 @@ class SyncDecorator(object):
 
         return SyncDecorator(user_insights_client)
 
-    def iterator_to_array(self, iterator):
+    async def iterator_to_array(self, iterator):
         def closure():
 
             objects = []
 
             while True:
                 try:
-                    obj = yield from iterator.__anext__()
+                    obj = await iterator.__anext__()
                 except Exception:
                     break
                 else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37,38,39}-sync
+    py{34,35,36,37,38,39}-sync
     py{34,35,36,37,38,39}-async
     format
     types
@@ -38,8 +38,6 @@ passenv =
     ALGOLIA_APPLICATION_ID_MCM
     ALGOLIA_ADMIN_KEY_MCM
 commands =
-    py27-sync: python -m unittest discover -v
-    py27-async: python -c 'print "No asynchronous tests for Python 2.7, skipping."'
     py{34,35,36}-{sync,async}: python -m unittest discover -v
     py{37,38,39}-{sync,async}: python -m unittest discover -v -k {posargs:*}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{34,35,36,37,38,39}-sync
-    py{34,35,36,37,38,39}-async
+    py{34,35,36,37,38,39,310,311}-sync
+    py{34,35,36,37,38,39,310,311}-async
     format
     types
 install_command = python -m pip install --user {opts} {packages}
@@ -26,9 +26,9 @@ deps =
     faker {[versions]faker}
     mock {[versions]mock}
     typing {[versions]typing}
-    py{34,35,36,37,38,39}-async: asyncio {[versions]asyncio}
-    py{34,35,36,37,38,39}-async: aiohttp {[versions]aiohttp}
-    py{34,35,36,37,38,39}-async: async_timeout {[versions]async_timeout}
+    py{34,35,36,37,38,39,310,311}-async: asyncio {[versions]asyncio}
+    py{34,35,36,37,38,39,310,311}-async: aiohttp {[versions]aiohttp}
+    py{34,35,36,37,38,39,310,311}-async: async_timeout {[versions]async_timeout}
 passenv =
     ALGOLIA_APPLICATION_ID_1
     ALGOLIA_ADMIN_KEY_1
@@ -39,7 +39,7 @@ passenv =
     ALGOLIA_ADMIN_KEY_MCM
 commands =
     py{34,35,36}-{sync,async}: python -m unittest discover -v
-    py{37,38,39}-{sync,async}: python -m unittest discover -v -k {posargs:*}
+    py{37,38,39,310,311}-{sync,async}: python -m unittest discover -v -k {posargs:*}
 
 [testenv:types]
 basepython = python3.8


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #549, Fix #551
| Need Doc update   | yes


## Describe your change

This PR removes support for python 2.7, adds support for python 3.11 and tests the project against 3.9, 3.10, and 3.11:
- Replaced all @asyncio.coroutine decorators by async def function def
- Replaced `yield from` with `await` or `return` statements
- Added python 3.9, 3.10, and 3.11 to tox and circleci

## What problem is this fixing?

Due to a removed syntax in python 3.11, the package was not working.