### PR TITLE
add await to helpers async when it is a coroutine

### DIFF
--- a/algoliasearch/helpers_async.py
+++ b/algoliasearch/helpers_async.py
@@ -43,7 +43,7 @@ def _gen_async(client, method):
             result.raw_response = await result.raw_response
 
         # We make sure we resolve the promise
-        if isinstance(result, types.GeneratorType):
+        if isinstance(result, (types.GeneratorType, types.CoroutineType)):
             result = await result
 
         return result


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Need Doc update   | no


## Describe your change
Add checking for coroutine on async gen helper to await it instead of just returning.

before:
```python
await (await self.client.search_async)
```

after:
```python
await self.client.search_async
```


## What problem is this fixing?

When using some async methods that simply returns the async transport (like search_async) we were having to manually call await twice (like below). It was happening because we were only awaiting things on the helper if they were a generator, but not if they were a coroutine. 
