### PR TITLE
Added realtime event methods for related products/content models.

### DIFF
--- a/algoliasearch/insights_client.py
+++ b/algoliasearch/insights_client.py
@@ -203,3 +203,95 @@ class UserInsightsClient:
             },
             request_options,
         )
+
+    def add_to_cart_object_ids(
+        self,
+        event_name,
+        index_name,
+        object_ids,
+        request_options=None,
+    ):
+        # type: (str, str, List[str], Optional[Union[dict, RequestOptions]]) -> dict  # noqa: E501
+
+        return self._insights_client.send_event(
+            {
+                "eventType": "conversion",
+                "eventSubtype": "addToCart",
+                "eventName": event_name,
+                "index": index_name,
+                "userToken": self._user_token,
+                "objectIds": object_ids,
+            },
+            request_options,
+        )
+
+    def add_to_cart_object_ids_after_search(
+        self,
+        event_name,
+        index_name,
+        object_ids,
+        positions,
+        query_id,
+        request_options=None,
+    ):
+        # type: (str, str, List[str], List[int], str, Optional[Union[dict, RequestOptions]]) -> dict  # noqa: E501
+
+        return self._insights_client.send_event(
+            {
+                "eventType": "conversion",
+                "eventSubtype": "addToCart",
+                "eventName": event_name,
+                "index": index_name,
+                "userToken": self._user_token,
+                "objectIds": object_ids,
+                "positions": positions,
+                "queryId": query_id,
+            },
+            request_options,
+        )
+
+    def purchased_object_ids(
+        self,
+        event_name,
+        index_name,
+        object_ids,
+        request_options=None,
+    ):
+        # type: (str, str, List[str], Optional[Union[dict, RequestOptions]]) -> dict  # noqa: E501
+
+        return self._insights_client.send_event(
+            {
+                "eventType": "conversion",
+                "eventSubtype": "purchase",
+                "eventName": event_name,
+                "index": index_name,
+                "userToken": self._user_token,
+                "objectIds": object_ids,
+            },
+            request_options,
+        )
+
+    def purchased_object_ids_after_search(
+        self,
+        event_name,
+        index_name,
+        object_ids,
+        positions,
+        query_id,
+        request_options=None,
+    ):
+        # type: (str, str, List[str], List[int], str, Optional[Union[dict, RequestOptions]]) -> dict  # noqa: E501
+
+        return self._insights_client.send_event(
+            {
+                "eventType": "conversion",
+                "eventSubtype": "purchase",
+                "eventName": event_name,
+                "index": index_name,
+                "userToken": self._user_token,
+                "objectIds": object_ids,
+                "positions": positions,
+                "queryId": query_id,
+            },
+            request_options,
+        )


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no
| Related Issue     | no
| Need Doc update   | yes


## Describe your change

For sending real-time event methods for related products/content models, I added the following missing methods:

- add_to_cart_object_ids
- add_to_cart_object_ids_after_search 
- purchased_object_ids
- purchased_object_ids_after_search

## What problem is this fixing?

Unable to send real-time events for the following (event-type , sub-event-type) combinations associated with the related products/content models:

- conversion, addToCart
-  conversion, purchase