### PR TITLE
Add py.typed to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,5 +45,9 @@ exclude =
     *.tests.*
     tests.*
 
+[options.package_data]
+algoliasearch =
+    py.typed
+
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #533
| Need Doc update   | yes


## Describe your change

According to [PEP 561](https://peps.python.org/pep-0561/) python packages need to include a `py.typed` file in the distributed package so that downstream clients can leverage its type annotations.

## What problem is this fixing?

By adding a `py.typed` file, this fixes an issue when running `mypy` in a downstream client:

```
algolia_search_service.py:4: error: Skipping analyzing "algoliasearch.search_client": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```